### PR TITLE
Fix for JSON RPC calls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN uv pip install --system -e .
 ENV YUGABYTEDB_URL="dbname=yugabyte host=host.docker.internal port=5433 user=yugabyte password=yugabyte load_balance=false"
 
 # Expose HTTP/SSE port
-EXPOSE 8080
+EXPOSE 8000
 
 # Run the server using uv
 ENTRYPOINT ["uv","--verbose", "run", "src/server.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/arm64 ghcr.io/astral-sh/uv:python3.11-bookworm-slim
+FROM python:3.10-slim
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM --platform=linux/arm64 ghcr.io/astral-sh/uv:python3.11-bookworm-slim
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -27,15 +27,14 @@ uv sync
 
 ## Configuration
 
-The server is configured using the following environment variable:
+The server is configured using the following:
 
-- `YUGABYTEDB_URL`: The connection string for your YugabyteDB database (e.g., `dbname=database_name host=hostname port=5433 user=username password=password`)
+| Environment Variable | Argument | Optional | Description |
+|----------------------|----------|----------|-------------|
+| `YUGABYTEDB_URL`     | `--yugabytedb-url` | No | Connection string for your YugabyteDB database (e.g., `dbname=database_name host=hostname port=5433 user=username password=password`) |
+| `YB_MCP_TRANSPORT`   | `--transport`     | Yes | Transport protocol to use: `stdio` or `http` (default: `stdio`) |
+| `YB_MCP_STATELESS_HTTP` | `--stateless-http`| Yes | Enable stateless Streamable-HTTP mode: `true` or `false` (default: `false`) |
 
-Example `.env` file:
-
-```
-YUGABYTEDB_URL=postgresql://user:password@localhost:5433/yugabyte
-```
 
 ## Usage
 
@@ -48,10 +47,16 @@ uv run src/server.py
 ```
 
 
-or with `Streamable-HTTP` transport:
+or with stateful `Streamable-HTTP` transport:
 
 ```bash
 uv run src/server.py --transport http
+```
+
+or with stateless `Streamable-HTTP` transport:
+
+```bash
+uv run src/server.py --transport http --stateless-http
 ```
 
 ### Running the Server with Docker
@@ -65,13 +70,36 @@ docker build -t mcp/yugabytedb .
 Run the container with `STDIO` transport:
 
 ```bash
-docker run -p 8080:8080 -e YUGABYTEDB_URL="your-db-url" mcp/yugabytedb
+docker run -p 8000:8000 -e YUGABYTEDB_URL="your-db-url" mcp/yugabytedb
 ```
 
 or with `Streamable-HTTP` transport:
 
+Stateful Server:
 ```bash
-docker run -p 8080:8080 -e YUGABYTEDB_URL="your-db-url" mcp/yugabytedb --transport=http
+docker run -p 8000:8000 \
+  -e YUGABYTEDB_URL="your-db-url" \
+  mcp/yugabytedb --transport=http
+
+```
+Stateless Server:
+```bash
+docker run -p 8000:8000 \
+  -e YUGABYTEDB_URL="your-db-url" \
+  -e YB_MCP_TRANSPORT=http \
+  -e YB_MCP_STATELESS_HTTP=true \
+  mcp/yugabytedb
+
+```
+Stateless Server with SSL enabled cluster:
+```bash
+docker run -p 8000:8000 \
+  -v /path/to/root.crt:/certs/root.crt:ro \
+  -e YUGABYTEDB_URL="your-db-url" \
+  mcp/yugabytedb \
+  --transport=http \
+  --stateless-http
+
 ```
 
 ### MCP Client Configuration
@@ -170,7 +198,7 @@ In the bottom panel of Cursor, click on "Output" and select "Cursor MCP" from th
    Or with Docker:
 
    ```bash
-   docker run -p 8080:8080 -e YUGABYTEDB_URL="..." mcp/yugabytedb --transport=http
+   docker run -p 8000:8000 -e YUGABYTEDB_URL="..." mcp/yugabytedb --transport=http
    ```
 
 2. Launch the inspector:
@@ -181,7 +209,7 @@ In the bottom panel of Cursor, click on "Output" and select "Cursor MCP" from th
 3. In the GUI, use the URL:
 
    ```
-   http://localhost:8080/invocations/mcp
+   http://localhost:8000/mcp
    ```
 
    - Change transport type to `Streamable-HTTP`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "yugabytedb-mcp-server"
-version = "1.0.2"
+version = "1.0.3"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -491,7 +491,7 @@ wheels = [
 
 [[package]]
 name = "yugabytedb-mcp-server"
-version = "1.0.1"
+version = "1.0.3"
 source = { virtual = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
### Problem :
When running the YugabyteDB MCP server over Streamable HTTP, simple JSON-RPC requests (e.g., tools/list) failed with errors such as:

Session not found (because the server defaulted to stateful mode and required an initialize handshake)

Invalid request parameters in case of tools/call

This made it difficult to:

Use the server with basic HTTP clients like curl

Run the server in horizontally scalable / stateless environments (Docker, Kubernetes, load balancers)


### Summary of Changes

#### 1. Added Stateless HTTP Mode Support
- Exposed FastMCP’s `stateless_http=True` via:
  - CLI flag: `--stateless-http`
  - Environment variable: `MCP_STATELESS_HTTP=true`
- In stateless mode:
  - No session or `initialize` call is required
  - Each JSON-RPC request is handled independently
  - `tools/list` and `tools/call` work directly over HTTP

#### 2. Made Transport Configurable
- Added support for selecting transport via:
  - CLI: `--transport {stdio,http}`
  - Environment variable: `YB_MCP_TRANSPORT=stdio|http`

#### 3. Centralized Configuration Parsing
- Added a unified parser supporting both CLI arguments and environment variables:
  - `YUGABYTEDB_URL` / `--yugabytedb-url`
  - `YB_MCP_TRANSPORT` / `--transport`
  - `MCP_STATELESS_HTTP` / `--stateless-http`

#### 4. Refactored into a Server Class
- Introduced `YugabyteDBMCPServer`, following the same structure as Falcon MCP:
  - Handles configuration
  - Registers tools
  - Runs in STDIO or Streamable HTTP
  - Cleanly supports both stateful and stateless modes

### Testing
#### 1. Created a Cloud Cluster, and ran the following command to start the MCP server:
```
docker run -p 8000:8000 -v /path/to/root.crt:/certs/root.crt:ro -e YUGABYTEDB_URL="host=hostname port=5433 dbname=yugabyte user=admin password=password sslmode=verify-full sslrootcert=/certs/root.crt" mcp/yugabytedb --transport=http --stateless-http
```
#### 2. Ran the following curl commands to test:
```
curl -X POST http://localhost:8000/mcp \
     -H "Content-Type: application/json" -H "Accept: application/json" \
     -d '{"jsonrpc": "2.0","id": 1,"method": "tools/list"}'
```
```
curl -X POST http://localhost:8000/mcp \
  -H "Content-Type: application/json" -H "Accept: application/json" \
  -d '{                                                    
  "jsonrpc": "2.0",
  "id": "1",
  "method": "tools/call",
  "params": {
    "name": "run_read_only_query",
    "arguments": {
      "query": "SELECT * from yb_servers();"
    }
  }
}'

```
#### 3. Also tested the existing `stdio` and `stateful streamable-http` support using Claude and MCP Inspector respectively.