### PR TITLE
Add Secrets Manager–based SSL root certificate support for secure YugabyteDB MCP connections

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/arm64 ghcr.io/astral-sh/uv:python3.11-bookworm-slim
+FROM python:3.10-slim
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM --platform=linux/arm64 ghcr.io/astral-sh/uv:python3.11-bookworm-slim
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ The server is configured using the following:
 | `YUGABYTEDB_URL`     | `--yugabytedb-url` | No | Connection string for your YugabyteDB database (e.g., `dbname=database_name host=hostname port=5433 user=username password=password`) |
 | `YB_MCP_TRANSPORT`   | `--transport`     | Yes | Transport protocol to use: `stdio` or `http` (default: `stdio`) |
 | `YB_MCP_STATELESS_HTTP` | `--stateless-http`| Yes | Enable stateless Streamable-HTTP mode: `true` or `false` (default: `false`) |
-| `YB_SSL_ROOT_CERT_SECRET_ARN` | `--yb-ssl-root-cert-secret-arn` | Yes | ARN of the AWS Secrets Manager secret containing the TLS root certificate |
-| `YB_SSL_ROOT_CERT_KEY` | `--yb-ssl-root-cert-key` | Yes | Key inside the secret JSON that selects which certificate to use |
+| `YB_AWS_SSL_ROOT_CERT_SECRET_ARN` | `--yb-aws-ssl-root-cert-secret-arn` | Yes | ARN of the AWS Secrets Manager secret containing the TLS root certificate |
+| `YB_AWS_SSL_ROOT_CERT_KEY` | `--yb-aws-ssl-root-cert-key` | Yes | Key inside the secret JSON that selects which certificate to use |
 | `YB_SSL_ROOT_CERT_PATH` | `--yb-ssl-root-cert-path` | Yes | Filesystem path where the root certificate will be written (default: `/tmp/yb-root.crt`) |
-| `YB_SSL_ROOT_CERT_SECRET_REGION` | `--yb-ssl-root-cert-secret-region` | Yes | Region of the AWS Secrets Manager secret containing the TLS root certificate |
+| `YB_AWS_SSL_ROOT_CERT_SECRET_REGION` | `--yb-aws-ssl-root-cert-secret-region` | Yes | Region of the AWS Secrets Manager secret containing the TLS root certificate |
 
 
 ## Usage
@@ -119,8 +119,8 @@ docker run -p 8000:8000 \
   -e YUGABYTEDB_URL="host=... port=5433 dbname=... user=... password=... sslmode=verify-full" \
   -e YB_MCP_TRANSPORT=http \
   -e YB_MCP_STATELESS_HTTP=true \
-  -e YB_SSL_ROOT_CERT_SECRET_ARN=arn:ofthe:secret:manager \
-  -e YB_SSL_ROOT_CERT_SECRET_REGION=region-of-the-secret-manager \
+  -e YB_AWS_SSL_ROOT_CERT_SECRET_ARN=arn:ofthe:secret:manager \
+  -e YB_AWS_SSL_ROOT_CERT_SECRET_REGION=region-of-the-secret-manager \
   -e AWS_ACCESS_KEY_ID="XXX" \
   -e AWS_SECRET_ACCESS_KEY="XXX" \
   -e AWS_SESSION_TOKEN="XXX" \
@@ -144,9 +144,9 @@ docker run -p 8000:8000 \
   -e YUGABYTEDB_URL="host=... port=5433 dbname=... user=... password=... sslmode=verify-full" \
   -e YB_MCP_TRANSPORT=http \
   -e YB_MCP_STATELESS_HTTP=true \
-  -e YB_SSL_ROOT_CERT_SECRET_ARN=arn:ofthe:secret:manager \
-  -e YB_SSL_ROOT_CERT_KEY=cert-cluster-1 \
-  -e YB_SSL_ROOT_CERT_SECRET_REGION=region-of-the-secret-manager \
+  -e YB_AWS_SSL_ROOT_CERT_SECRET_ARN=arn:ofthe:secret:manager \
+  -e YB_AWS_SSL_ROOT_CERT_KEY=cert-cluster-1 \
+  -e YB_AWS_SSL_ROOT_CERT_SECRET_REGION=region-of-the-secret-manager \
   -e AWS_ACCESS_KEY_ID="XXX" \
   -e AWS_SECRET_ACCESS_KEY="XXX" \
   -e AWS_SESSION_TOKEN="XXX" \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,4 +9,5 @@ dependencies = [
     "httpx~=0.28.0",
     "fastapi>=0.115.12",
     "psycopg2-binary>=2.9.10",
+    "boto3>=1.42.37",
 ]

--- a/src/server.py
+++ b/src/server.py
@@ -65,7 +65,7 @@ def write_root_cert():
                 # Backward-compatible: allow exactly one entry
                 if len(data) != 1:
                     raise RuntimeError(
-                        "Multiple certificates found in secret; set YB_SSL_ROOT_CERT_KEY to select one"
+                        "Multiple certificates found in secret; set YB_AWS_SSL_ROOT_CERT_KEY to select one"
                     )
                 pem = next(iter(data.values()))
         
@@ -180,13 +180,13 @@ def parse_config() -> argparse.Namespace:
         help="YugabyteDB connection string (env: YUGABYTEDB_URL)",
     )
     parser.add_argument(
-        "--yb-ssl-root-cert-secret-arn", 
-        default=os.getenv("YB_SSL_ROOT_CERT_SECRET_ARN"),
+        "--yb-aws-ssl-root-cert-secret-arn", 
+        default=os.getenv("YB_AWS_SSL_ROOT_CERT_SECRET_ARN"),
         help="ARN of the AWS Secrets Manager secret containing the TLS root certificate",
     )
     parser.add_argument(
-        "--yb-ssl-root-cert-key", 
-        default=os.getenv("YB_SSL_ROOT_CERT_KEY"),
+        "--yb-aws-ssl-root-cert-key", 
+        default=os.getenv("YB_AWS_SSL_ROOT_CERT_KEY"),
         help="Key inside the secret JSON that selects which certificate to use",
     )
     parser.add_argument(
@@ -195,8 +195,8 @@ def parse_config() -> argparse.Namespace:
           help="Filesystem path where the root certificate will be written (default: `/tmp/yb-root.crt`)"
     )
     parser.add_argument(
-        "--yb-ssl-root-cert-secret-region",
-          default=os.getenv("YB_SSL_ROOT_CERT_SECRET_REGION"),
+        "--yb-aws-ssl-root-cert-secret-region",
+          default=os.getenv("YB_AWS_SSL_ROOT_CERT_SECRET_REGION"),
           help="Region of the AWS Secrets Manager secret containing the TLS root certificate",
     )
 
@@ -205,10 +205,10 @@ def parse_config() -> argparse.Namespace:
         yugabytedb_url=args.yugabytedb_url,
         transport=args.transport,
         stateless_http=args.stateless_http,
-        ssl_root_cert_secret_arn=args.yb_ssl_root_cert_secret_arn,
-        ssl_root_cert_key=args.yb_ssl_root_cert_key,
+        ssl_root_cert_secret_arn=args.yb_aws_ssl_root_cert_secret_arn,
+        ssl_root_cert_key=args.yb_aws_ssl_root_cert_key,
         ssl_root_cert_path=args.yb_ssl_root_cert_path,
-        ssl_root_cert_secret_region=args.yb_ssl_root_cert_secret_region,
+        ssl_root_cert_secret_region=args.yb_aws_ssl_root_cert_secret_region,
     )
 
 

--- a/src/server.py
+++ b/src/server.py
@@ -11,19 +11,86 @@ from mcp.server.fastmcp import FastMCP, Context
 import uvicorn
 from fastapi import FastAPI
 from starlette.responses import JSONResponse
+import boto3
 
 @dataclass
 class AppContext:
     conn: psycopg2.extensions.connection
 
+@dataclass
+class ServerConfig:
+    yugabytedb_url: str
+    transport: str
+    stateless_http: bool
+    ssl_root_cert_secret_arn: str | None
+    ssl_root_cert_key: str | None
+    ssl_root_cert_path: str
+    ssl_root_cert_secret_region: str
+
+def normalize_pem(pem: str) -> str:
+    # Remove surrounding spaces
+    pem = pem.strip()
+
+    # Fix cases where newlines were replaced by spaces
+    pem = pem.replace("-----BEGIN CERTIFICATE----- ", "-----BEGIN CERTIFICATE-----\n")
+    pem = pem.replace(" -----END CERTIFICATE-----", "\n-----END CERTIFICATE-----")
+
+    # Also fix intermediate blocks
+    pem = pem.replace("-----END CERTIFICATE-----  -----BEGIN CERTIFICATE-----",
+                      "-----END CERTIFICATE-----\n\n-----BEGIN CERTIFICATE-----")
+
+    return pem + "\n"
+
+
+def write_root_cert():
+    if not CONFIG.ssl_root_cert_secret_arn:
+        return None
+
+    try:
+        sm = boto3.client("secretsmanager", region_name=CONFIG.ssl_root_cert_secret_region)
+        resp = sm.get_secret_value(SecretId=CONFIG.ssl_root_cert_secret_arn)
+        secret_string = resp["SecretString"]
+
+        # If raw PEM, just use it
+        if "BEGIN CERTIFICATE" in secret_string and not secret_string.strip().startswith("{"):
+            pem = secret_string
+        else:
+            data = json.loads(secret_string)
+
+            if CONFIG.ssl_root_cert_key:
+                if CONFIG.ssl_root_cert_key not in data:
+                    raise RuntimeError(f"Certificate key '{CONFIG.ssl_root_cert_key}' not found in secret")
+                pem = data[CONFIG.ssl_root_cert_key]
+            else:
+                # Backward-compatible: allow exactly one entry
+                if len(data) != 1:
+                    raise RuntimeError(
+                        "Multiple certificates found in secret; set YB_SSL_ROOT_CERT_KEY to select one"
+                    )
+                pem = next(iter(data.values()))
+        
+        pem = normalize_pem(pem)
+        with open(CONFIG.ssl_root_cert_path, "w") as f:
+            f.write(pem.strip() + "\n")
+
+        return CONFIG.ssl_root_cert_path
+
+    except Exception as e:
+        print(f"Failed to load root cert from Secrets Manager: {e}", file=sys.stderr)
+        raise
+
+
 @asynccontextmanager
 async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:
-    database_url = os.getenv("YUGABYTEDB_URL")
-    if not database_url:
+    if not CONFIG.yugabytedb_url:
         print("YUGABYTEDB_URL is not set", file=sys.stderr)
         sys.exit(1)
 
     print("Connecting to database...", file=sys.stderr)
+    database_url = CONFIG.yugabytedb_url
+    cert_path = write_root_cert()
+    if cert_path and "sslrootcert" not in database_url:
+        database_url += f" sslrootcert={cert_path}"
     conn = psycopg2.connect(database_url)
     try:
         yield AppContext(conn=conn)
@@ -112,19 +179,47 @@ def parse_config() -> argparse.Namespace:
         default=os.environ.get("YUGABYTEDB_URL"),
         help="YugabyteDB connection string (env: YUGABYTEDB_URL)",
     )
-    return parser.parse_args()
+    parser.add_argument(
+        "--yb-ssl-root-cert-secret-arn", 
+        default=os.getenv("YB_SSL_ROOT_CERT_SECRET_ARN"),
+        help="ARN of the AWS Secrets Manager secret containing the TLS root certificate",
+    )
+    parser.add_argument(
+        "--yb-ssl-root-cert-key", 
+        default=os.getenv("YB_SSL_ROOT_CERT_KEY"),
+        help="Key inside the secret JSON that selects which certificate to use",
+    )
+    parser.add_argument(
+        "--yb-ssl-root-cert-path",
+          default=os.getenv("YB_SSL_ROOT_CERT_PATH","/tmp/yb-root.crt"),
+          help="Filesystem path where the root certificate will be written (default: `/tmp/yb-root.crt`)"
+    )
+    parser.add_argument(
+        "--yb-ssl-root-cert-secret-region",
+          default=os.getenv("YB_SSL_ROOT_CERT_SECRET_REGION"),
+          help="Region of the AWS Secrets Manager secret containing the TLS root certificate",
+    )
+
+    args = parser.parse_args()
+    return ServerConfig(
+        yugabytedb_url=args.yugabytedb_url,
+        transport=args.transport,
+        stateless_http=args.stateless_http,
+        ssl_root_cert_secret_arn=args.yb_ssl_root_cert_secret_arn,
+        ssl_root_cert_key=args.yb_ssl_root_cert_key,
+        ssl_root_cert_path=args.yb_ssl_root_cert_path,
+        ssl_root_cert_secret_region=args.yb_ssl_root_cert_secret_region,
+    )
 
 
 class YugabyteDBMCPServer:
-    def __init__(self, transport: str, stateless_http: bool):
-        self.transport = transport
-        self.stateless_http = stateless_http
+    def __init__(self):
 
         self.mcp = FastMCP(
             "yugabytedb-mcp",
             lifespan=app_lifespan,
             json_response=True,
-            stateless_http=stateless_http,
+            stateless_http=CONFIG.stateless_http,
         )
 
         self._register_tools()
@@ -134,7 +229,7 @@ class YugabyteDBMCPServer:
         self.mcp.add_tool(run_read_only_query)
 
     def run(self, host="0.0.0.0", port=8000):
-        if self.transport == "http":
+        if CONFIG.transport == "http":
             self._run_http(host, port)
         else:
             self.mcp.run(transport="stdio")
@@ -158,11 +253,6 @@ class YugabyteDBMCPServer:
 
 
 if __name__ == "__main__":
-    cfg = parse_config()
-
-    server = YugabyteDBMCPServer(
-        transport=cfg.transport,
-        stateless_http=cfg.stateless_http,
-    )
-
+    CONFIG = parse_config()
+    server = YugabyteDBMCPServer()
     server.run()

--- a/uv.lock
+++ b/uv.lock
@@ -27,6 +27,34 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.42.37"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/ef/0d6ceb88ae2b3638b956190a431e4a8a3697d5769d4bbbede8efcccacaea/boto3-1.42.37.tar.gz", hash = "sha256:d8b6c52c86f3bf04f71a5a53e7fb4d1527592afebffa5170cf3ef7d70966e610", size = 112830, upload-time = "2026-01-28T20:38:43.339Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/a4/cd334f74498acc6ad42a69c48e8c495f6f721d8abe13f8ef0d4b862fb1c0/boto3-1.42.37-py3-none-any.whl", hash = "sha256:e1e38fd178ffc66cfbe9cb6838b8c460000c3eb741e5f40f57eb730780ef0ed4", size = 140604, upload-time = "2026-01-28T20:38:42.135Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.42.37"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d5/4d/94292e7686e64d2ede8dae7102bbb11a1474e407c830de4192f2518e6cff/botocore-1.42.37.tar.gz", hash = "sha256:3ec58eb98b0857f67a2ae6aa3ded51597e7335f7640be654e0e86da4f173b5b2", size = 14914621, upload-time = "2026-01-28T20:38:34.586Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/30/54042dd3ad8161964f8f47aa418785079bd8d2f17053c40d65bafb9f6eed/botocore-1.42.37-py3-none-any.whl", hash = "sha256:f13bb8b560a10714d96fb7b0c7f17828dfa6e6606a1ead8c01c6ebb8765acbd8", size = 14589390, upload-time = "2026-01-28T20:38:31.306Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2025.4.26"
 source = { registry = "https://pypi.org/simple" }
@@ -135,6 +163,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
 ]
 
 [[package]]
@@ -365,6 +402,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -397,12 +446,33 @@ wheels = [
 ]
 
 [[package]]
+name = "s3transfer"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827, upload-time = "2025-12-01T02:30:59.114Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", size = 86830, upload-time = "2025-12-01T02:30:57.729Z" },
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]
@@ -476,6 +546,15 @@ wheels = [
 ]
 
 [[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
 name = "uvicorn"
 version = "0.34.2"
 source = { registry = "https://pypi.org/simple" }
@@ -494,6 +573,7 @@ name = "yugabytedb-mcp-server"
 version = "1.0.3"
 source = { virtual = "." }
 dependencies = [
+    { name = "boto3" },
     { name = "fastapi" },
     { name = "httpx" },
     { name = "mcp", extra = ["cli"] },
@@ -502,6 +582,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "boto3", specifier = ">=1.42.37" },
     { name = "fastapi", specifier = ">=0.115.12" },
     { name = "httpx", specifier = "~=0.28.0" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.9.4" },


### PR DESCRIPTION
## Problem

When running the YugabyteDB MCP server against SSL-enabled YugabyteDB clusters (such as YugabyteDB Managed or secure self-hosted clusters), users must provide a root CA certificate for TLS verification (`sslmode=verify-full`).

Previously, this was only possible by:

- Mounting a local `root.crt` file into the container and hardcoding the file path in `YUGABYTEDB_URL`, or  
- Modifying the container image to bake the certificate inside.

This approach does not work well for:

- Hosted MCP environments (e.g. Bedrock AgentCore, ECS)
There was no first-class way to provide certificates via a secure secret store such as AWS Secrets Manager, nor a clean way to select between multiple certificates stored in a single secret.

---

## Solution

This PR adds native support for loading YugabyteDB root certificates from AWS Secrets Manager and wiring them into the PostgreSQL connection at runtime.

### Key Enhancements

1. **Secrets Manager integration**
   - Load root CA certificates directly from AWS Secrets Manager.
   - Supports both:
     - Plaintext PEM secrets
     - JSON secrets containing one or more certificates

2. **Multiple certificate support**
   - Multiple certificates can be stored in a single secret (e.g. `cert-cluster-1`, `cert-cluster-2`).
   - A selector (`YB_SSL_ROOT_CERT_KEY`) allows choosing which certificate to use.

3. **Automatic PEM normalization**
   - Handles PEM stored with escaped newlines, space-collapsed lines, or concatenated chains.
   - Writes a valid PEM file and injects it via `sslrootcert` for psycopg2.

4. **Backward compatible**
   - If no secret ARN is provided, the server behaves exactly as before and relies on system trust store or explicit `sslrootcert` in the connection string.

---

## How to Test

### 1. Build the docker image for YugabyteDB MCP Server:
```
docker build -t mcp/yugabytedb .
```
### 2. Create a secret containing on the AWS Secret Manager Console. You can store the .crt file as either:
#### a. Plaintext PEM
Copy paste the entire contents of the .crt file in the plaintext section when creating the new secret.
Then run:
```bash
docker run -p 8000:8000 \
  -e YUGABYTEDB_URL="host=... port=5433 dbname=... user=... password=... sslmode=verify-full" \
  -e YB_MCP_TRANSPORT=http \
  -e YB_MCP_STATELESS_HTTP=true \
  -e YB_SSL_ROOT_CERT_SECRET_ARN=arn:ofthe:secret:manager \
  -e YB_SSL_ROOT_CERT_SECRET_REGION=region-of-the-secret-manager \
  -e AWS_ACCESS_KEY_ID="XXX" \
  -e AWS_SECRET_ACCESS_KEY="XXX" \
  -e AWS_SESSION_TOKEN="XXX" \
  mcp/yugabytedb
  ```
#### b. JSON (In case of multiple certificates in the same secrets manager)
```json

{
  "cert-cluster-1": "-----BEGIN CERTIFICATE----- ...",
  "cert-cluster-2": "-----BEGIN CERTIFICATE----- ..."
}
```
Select which certificate to use:

```bash
docker run -p 8000:8000 \
  -e YUGABYTEDB_URL="host=... port=5433 dbname=... user=... password=... sslmode=verify-full" \
  -e YB_MCP_TRANSPORT=http \
  -e YB_MCP_STATELESS_HTTP=true \
  -e YB_SSL_ROOT_CERT_SECRET_ARN=arn:ofthe:secret:manager \
  -e YB_SSL_ROOT_CERT_KEY=cert-cluster-1 \
  -e YB_SSL_ROOT_CERT_SECRET_REGION=region-of-the-secret-manager \
  -e AWS_ACCESS_KEY_ID="XXX" \
  -e AWS_SECRET_ACCESS_KEY="XXX" \
  -e AWS_SESSION_TOKEN="XXX" \
  mcp/yugabytedb
```
### 3. Once the server starts, run the following commands:
```
curl -X POST http://localhost:8000/mcp \
     -H "Content-Type: application/json" -H "Accept: application/json" \
     -d '{"jsonrpc": "2.0","id": 1,"method": "tools/list"}'
```
```
curl -X POST http://localhost:8000/mcp \
  -H "Content-Type: application/json" -H "Accept: application/json" \   
  -d '{                                                    
  "jsonrpc": "2.0",
  "id": "1",
  "method": "tools/call",
  "params": {
    "name": "run_read_only_query",
    "arguments": {
      "query": "SELECT * from yb_servers();"
    }
  }
}'

```
