### PR TITLE
Put the write tool behind a flag

### DIFF
--- a/src/yugabytedb_mcp_server/server.py
+++ b/src/yugabytedb_mcp_server/server.py
@@ -36,6 +36,7 @@ class ServerConfig:
     require_where_on_update: bool
     require_where_on_delete: bool
     auth_provider: str | None
+    enable_write_query: bool
 
 
 def normalize_pem(pem: str) -> str:
@@ -197,6 +198,12 @@ def parse_config() -> ServerConfig:
         help="Reject DELETE without WHERE clause (env: YB_MCP_REQUIRE_WHERE_ON_DELETE=true)",
     )
     parser.add_argument(
+        "--enable-write-query",
+        action="store_true",
+        default=os.environ.get("YB_MCP_ENABLE_WRITE_QUERY", "").lower() == "true",
+        help="Enable the run_write_query tool (disabled by default) (env: YB_MCP_ENABLE_WRITE_QUERY=true)",
+    )
+    parser.add_argument(
         "--mcp-auth-provider",
         default=os.environ.get("MCP_AUTH_PROVIDER"),
         help="Auth provider for the MCP server: 'cognito' or 'oidc'. Leave unset to disable auth (env: MCP_AUTH_PROVIDER)",
@@ -215,6 +222,7 @@ def parse_config() -> ServerConfig:
         require_where_on_update=args.require_where_on_update,
         require_where_on_delete=args.require_where_on_delete,
         auth_provider=args.mcp_auth_provider,
+        enable_write_query=args.enable_write_query,
     )
 
 
@@ -241,10 +249,14 @@ class YugabyteDBMCPServer:
             run_read_only_query,
             annotations={**_ro, "title": "Run a read-only SQL query"},
         )
-        self.mcp.tool(
-            run_write_query,
-            annotations={**_dest, "title": "Run a write SQL query (with guardrails)"},
-        )
+        if CONFIG.enable_write_query:
+            self.mcp.tool(
+                run_write_query,
+                annotations={**_dest, "title": "Run a write SQL query (with guardrails)"},
+            )
+            logger.info("run_write_query tool enabled")
+        else:
+            logger.info("run_write_query tool disabled (use --enable-write-query or YB_MCP_ENABLE_WRITE_QUERY=true to enable)")
 
     def run(self, host="0.0.0.0", port=8000):
         if CONFIG.transport == "http":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,7 +107,7 @@ def _server_params(extra_env: dict | None = None) -> StdioServerParameters:
 
 @pytest_asyncio.fixture
 async def mcp_session():
-    """Initialized MCP ClientSession over stdio for the default config."""
+    """Initialized MCP ClientSession over stdio for the default config (write tool disabled)."""
     stdio_cm = stdio_client(_server_params())
     read_stream, write_stream = await stdio_cm.__aenter__()
     session_cm = ClientSession(read_stream, write_stream)
@@ -121,9 +121,27 @@ async def mcp_session():
 
 
 @pytest_asyncio.fixture
-async def mcp_session_strict():
-    """MCP session with strict WHERE-clause enforcement and a lower bulk-INSERT limit."""
+async def mcp_session_write_enabled():
+    """MCP session with the run_write_query tool enabled."""
     stdio_cm = stdio_client(_server_params(extra_env={
+        "YB_MCP_ENABLE_WRITE_QUERY": "true",
+    }))
+    read_stream, write_stream = await stdio_cm.__aenter__()
+    session_cm = ClientSession(read_stream, write_stream)
+    session = await session_cm.__aenter__()
+    await session.initialize()
+    try:
+        yield session
+    finally:
+        await _safe_aexit(session_cm)
+        await _safe_aexit(stdio_cm)
+
+
+@pytest_asyncio.fixture
+async def mcp_session_strict():
+    """MCP session with strict WHERE-clause enforcement, a lower bulk-INSERT limit, and write enabled."""
+    stdio_cm = stdio_client(_server_params(extra_env={
+        "YB_MCP_ENABLE_WRITE_QUERY": "true",
         "YB_MCP_REQUIRE_WHERE_ON_UPDATE": "true",
         "YB_MCP_REQUIRE_WHERE_ON_DELETE": "true",
         "YB_MCP_MAX_INSERT_ROWS": "5",

--- a/tests/test_integration_guardrails.py
+++ b/tests/test_integration_guardrails.py
@@ -29,7 +29,7 @@ pytestmark = [requires_yugabytedb, pytest.mark.asyncio]
     ("\\d", "meta-command"),
 ])
 async def test_blocked_query_returns_guardrail_error(
-    mcp_session, blocked_query, expected_fragment, test_schema, db_conn
+    mcp_session_write_enabled, blocked_query, expected_fragment, test_schema, db_conn
 ):
     """For each class of blocked statement, confirm:
     - tool returns {"error": ..., "blocked_by_guardrail": True}
@@ -40,7 +40,7 @@ async def test_blocked_query_returns_guardrail_error(
         cur.execute(f'CREATE TABLE "{test_schema}".witness (id INT)')
         cur.execute(f'INSERT INTO "{test_schema}".witness VALUES (1)')
 
-    result = await mcp_session.call_tool("run_write_query", {"query": blocked_query})
+    result = await mcp_session_write_enabled.call_tool("run_write_query", {"query": blocked_query})
     payload = parse_json(result)
     assert payload.get("blocked_by_guardrail") is True, payload
     assert expected_fragment in payload.get("error", ""), payload
@@ -51,11 +51,11 @@ async def test_blocked_query_returns_guardrail_error(
         assert cur.fetchone() == (1,)
 
 
-async def test_blocked_create_extension_no_side_effect(mcp_session, db_conn):
+async def test_blocked_create_extension_no_side_effect(mcp_session_write_enabled, db_conn):
     """CREATE EXTENSION is blocked. Confirm by attempting to create an extension
     that would otherwise succeed (citext is on most YugabyteDB installs) and
     verify it's NOT in pg_extension after the call."""
-    result = await mcp_session.call_tool(
+    result = await mcp_session_write_enabled.call_tool(
         "run_write_query",
         {"query": "CREATE EXTENSION IF NOT EXISTS citext"},
     )

--- a/tests/test_integration_write_flag.py
+++ b/tests/test_integration_write_flag.py
@@ -1,0 +1,33 @@
+"""Integration tests for the --enable-write-query / YB_MCP_ENABLE_WRITE_QUERY flag.
+
+Verifies that the run_write_query tool is only available when explicitly enabled.
+
+Requires YUGABYTEDB_URL.
+"""
+import pytest
+
+import sys
+import pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+from _helpers import requires_yugabytedb  # noqa: E402
+
+
+pytestmark = [requires_yugabytedb, pytest.mark.asyncio]
+
+
+async def test_write_tool_absent_by_default(mcp_session):
+    """With default config, run_write_query must NOT be listed."""
+    tools = await mcp_session.list_tools()
+    tool_names = {t.name for t in tools.tools}
+    assert "run_write_query" not in tool_names
+    assert "summarize_database" in tool_names
+    assert "run_read_only_query" in tool_names
+
+
+async def test_write_tool_present_when_enabled(mcp_session_write_enabled):
+    """With YB_MCP_ENABLE_WRITE_QUERY=true, run_write_query must be listed."""
+    tools = await mcp_session_write_enabled.list_tools()
+    tool_names = {t.name for t in tools.tools}
+    assert "run_write_query" in tool_names
+    assert "summarize_database" in tool_names
+    assert "run_read_only_query" in tool_names

--- a/tests/test_integration_writes.py
+++ b/tests/test_integration_writes.py
@@ -17,13 +17,13 @@ from _helpers import requires_yugabytedb, parse_json, raw_text  # noqa: E402
 pytestmark = [requires_yugabytedb, pytest.mark.asyncio]
 
 
-async def test_insert_round_trip(mcp_session, test_schema, db_conn):
+async def test_insert_round_trip(mcp_session_write_enabled, test_schema, db_conn):
     # Seed empty table via side-channel
     with db_conn.cursor() as cur:
         cur.execute(f'CREATE TABLE "{test_schema}".t (id INT, name TEXT)')
 
     # Insert via MCP tool
-    result = await mcp_session.call_tool(
+    result = await mcp_session_write_enabled.call_tool(
         "run_write_query",
         {"query": f'INSERT INTO "{test_schema}".t (id, name) VALUES (1, \'alice\')'},
     )
@@ -37,12 +37,12 @@ async def test_insert_round_trip(mcp_session, test_schema, db_conn):
     assert rows == [(1, "alice")]
 
 
-async def test_update_round_trip(mcp_session, test_schema, db_conn):
+async def test_update_round_trip(mcp_session_write_enabled, test_schema, db_conn):
     with db_conn.cursor() as cur:
         cur.execute(f'CREATE TABLE "{test_schema}".t (id INT, c TEXT)')
         cur.execute(f'INSERT INTO "{test_schema}".t VALUES (1, \'old\'), (2, \'keep\')')
 
-    result = await mcp_session.call_tool(
+    result = await mcp_session_write_enabled.call_tool(
         "run_write_query",
         {"query": f'UPDATE "{test_schema}".t SET c = \'new\' WHERE id = 1'},
     )
@@ -55,12 +55,12 @@ async def test_update_round_trip(mcp_session, test_schema, db_conn):
     assert rows == [(1, "new"), (2, "keep")]
 
 
-async def test_delete_round_trip(mcp_session, test_schema, db_conn):
+async def test_delete_round_trip(mcp_session_write_enabled, test_schema, db_conn):
     with db_conn.cursor() as cur:
         cur.execute(f'CREATE TABLE "{test_schema}".t (id INT)')
         cur.execute(f'INSERT INTO "{test_schema}".t VALUES (1), (2), (3)')
 
-    result = await mcp_session.call_tool(
+    result = await mcp_session_write_enabled.call_tool(
         "run_write_query",
         {"query": f'DELETE FROM "{test_schema}".t WHERE id IN (1, 3)'},
     )
@@ -73,12 +73,12 @@ async def test_delete_round_trip(mcp_session, test_schema, db_conn):
     assert rows == [(2,)]
 
 
-async def test_bulk_insert_under_limit_succeeds(mcp_session, test_schema, db_conn):
+async def test_bulk_insert_under_limit_succeeds(mcp_session_write_enabled, test_schema, db_conn):
     with db_conn.cursor() as cur:
         cur.execute(f'CREATE TABLE "{test_schema}".t (id INT)')
 
     rows = ", ".join(f"({i})" for i in range(10))
-    result = await mcp_session.call_tool(
+    result = await mcp_session_write_enabled.call_tool(
         "run_write_query",
         {"query": f'INSERT INTO "{test_schema}".t VALUES {rows}'},
     )
@@ -147,10 +147,10 @@ async def test_strict_delete_without_where_blocked(mcp_session_strict, test_sche
         assert cur.fetchone()[0] == 2
 
 
-async def test_write_query_postgres_error_returns_json(mcp_session, test_schema, db_conn):
+async def test_write_query_postgres_error_returns_json(mcp_session_write_enabled, test_schema, db_conn):
     """Errors from the DB (not from guardrails) should also come back as a
     well-formed JSON response, not crash the tool."""
-    result = await mcp_session.call_tool(
+    result = await mcp_session_write_enabled.call_tool(
         "run_write_query",
         {"query": f'INSERT INTO "{test_schema}".does_not_exist VALUES (1)'},
     )


### PR DESCRIPTION
- Put the `run_write_query()` tool behind a flag
- By default it's disabled