### PR TITLE
OIDC-to-Postgres-role mapping with example tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An [MCP](https://modelcontextprotocol.io/) server for YugabyteDB and PostgreSQL 
 
 - **`summarize_database`** — list tables with columns and row counts for a schema (read-only)
 - **`run_read_only_query`** — execute a SELECT under `BEGIN READ ONLY`; results returned as JSON (read-only)
-- **`run_write_query`** — INSERT/UPDATE/DELETE/MERGE/TRUNCATE/DDL gated by a guardrail blocklist (destructive)
+- **`run_write_query`** — INSERT/UPDATE/DELETE/MERGE/TRUNCATE/DDL gated by a guardrail blocklist (destructive, **disabled by default** — enable with `--enable-write-query` or `YB_MCP_ENABLE_WRITE_QUERY=true`)
 
 Defense in depth: the write tool is annotated `destructiveHint: true`, so Claude Desktop surfaces a confirmation prompt before every call even when the guardrails would let the statement through.
 
@@ -67,7 +67,10 @@ For development from source, see [Development](#development) below.
 | `YB_MCP_MAX_INSERT_ROWS` | `--max-insert-rows` | No | Reject INSERT … VALUES with more rows than this. Default `1000`. |
 | `YB_MCP_REQUIRE_WHERE_ON_UPDATE` | `--require-where-on-update` | No | Reject UPDATE without a WHERE clause. Default `false`. |
 | `YB_MCP_REQUIRE_WHERE_ON_DELETE` | `--require-where-on-delete` | No | Reject DELETE without a WHERE clause. Default `false`. |
+| `YB_MCP_ENABLE_WRITE_QUERY` | `--enable-write-query` | No | Enable the `run_write_query` tool. Default `false` (write tool disabled). |
 | `MCP_AUTH_PROVIDER` | `--mcp-auth-provider` | No | `cognito` (tested) or `oidc` (untested). Leave unset to disable auth. |
+| `YB_MCP_IDENTITY_CLAIM` | `--identity-claim` | No | JWT claim to use as the DB role identifier for per-user `SET ROLE`. Default `email`. |
+| `YB_MCP_IDENTITY_TRANSFORM` | `--identity-transform` | No | Transform applied to the claim before using as a DB role: `none` (default) or `strip_domain` (strips `@…` from emails). |
 | `MCP_BASE_URL` | — | When auth enabled | Public base URL the server is reachable at (e.g. `https://mcp.example.com`). |
 | `MCP_ALLOWED_ORIGINS` | — | No | Comma-separated allowlist of Origin values for DNS-rebinding defense. Defaults to `MCP_BASE_URL`. |
 | `YB_LOG_LEVEL` | — | No | Log level for the `yugabytedb-mcp` logger family (default `INFO`). |
@@ -156,7 +159,7 @@ npx @modelcontextprotocol/inspector
 |---|---|---|---|
 | `summarize_database(schema='public')` | "Summarize database schema and row counts" | `readOnlyHint: true` | Lists tables in `schema` with columns and row counts |
 | `run_read_only_query(query)` | "Run a read-only SQL query" | `readOnlyHint: true` | Wraps the query in `BEGIN READ ONLY` and returns rows as JSON |
-| `run_write_query(query)` | "Run a write SQL query (with guardrails)" | `destructiveHint: true` | Validates the query against the guardrail blocklist, then executes |
+| `run_write_query(query)` | "Run a write SQL query (with guardrails)" | `destructiveHint: true` | Validates the query against the guardrail blocklist, then executes. **Disabled by default** — requires `--enable-write-query`. |
 
 ### Guardrails for `run_write_query`
 
@@ -226,6 +229,44 @@ The endpoint uses Cognito's `USER_PASSWORD_AUTH` flow under the hood — the Cog
 
 OIDC (`MCP_AUTH_PROVIDER=oidc`) wiring exists but is untested; please share findings if you exercise it.
 
+### Per-user database roles (SET ROLE)
+
+When OIDC auth is enabled, the server can map each authenticated user to a YugabyteDB database role using `SET ROLE`. This enforces row-level security, schema-level grants, and per-user privilege boundaries — the same connection pool is used, but each tool call runs under the caller's database role.
+
+```bash
+export YB_MCP_IDENTITY_CLAIM=email             # JWT claim to extract (default)
+export YB_MCP_IDENTITY_TRANSFORM=strip_domain  # alice@example.com → alice
+```
+
+**How it works:**
+
+1. The server extracts the configured claim from the OIDC access token.
+2. An optional transform derives the DB role name (e.g., stripping `@domain`).
+3. Before executing tool SQL, the server issues `SET ROLE <role>` on the pooled connection.
+4. After execution, `RESET ROLE` restores the connection to the pool user.
+
+**Requirements:**
+
+- The pool user (from `YUGABYTEDB_URL`) must be a superuser **or** have `GRANT <target_role> TO <pool_user>` for every role that can authenticate.
+- Target roles must already exist in the database — the server does not create them.
+- When auth is disabled (no `MCP_AUTH_PROVIDER`), SET ROLE is not used and the pool operates with its configured credentials as before.
+
+**Example setup:**
+
+```sql
+-- Create per-user roles matching the identity claim
+CREATE ROLE alice LOGIN;
+CREATE ROLE bob LOGIN;
+
+-- Grant them to the pool user so SET ROLE works
+GRANT alice TO mcp_admin;
+GRANT bob TO mcp_admin;
+
+-- Apply per-role permissions as needed
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO alice;
+GRANT ALL ON ALL TABLES IN SCHEMA public TO bob;
+```
+
 ## AWS Secrets Manager for TLS certificates
 
 If your database TLS root certificate is stored in AWS Secrets Manager, the server can fetch and use it automatically. Plaintext PEM is supported; JSON-keyed bundles too (set `YB_AWS_SSL_ROOT_CERT_KEY` to pick one).
@@ -247,8 +288,10 @@ docker run -p 8000:8000 -e YUGABYTEDB_URL="…" mcp/yugabytedb yugabytedb-mcp --
 ## Security
 
 - All SQL is run through parameterized queries; user input is never interpolated into statement strings.
+- The write tool is **disabled by default** — must be explicitly enabled with `--enable-write-query`.
 - The write tool's guardrail list (above) blocks the highest-risk statement classes.
 - `destructiveHint: true` ensures Claude Desktop surfaces a per-call confirmation for write operations.
+- When OIDC auth is active, per-user `SET ROLE` enforces database-level privilege boundaries per caller. Role names are safely quoted with `psycopg.sql.Identifier`.
 - HTTP transport requires a valid Bearer token when `MCP_AUTH_PROVIDER` is configured.
 - HTTP transport validates the `Origin` header against `MCP_ALLOWED_ORIGINS` (defaults to `MCP_BASE_URL`).
 - HTTPS is the operator's responsibility — terminate TLS at a reverse proxy (nginx, ALB, etc.) in front of the server.
@@ -316,7 +359,7 @@ Drag the resulting `.mcpb` into Claude Desktop — the connector installer UI ta
 
 ```bash
 # unit tests (no DB, no network)
-uv run pytest tests/test_guardrails.py tests/test_auth.py
+uv run pytest tests/test_guardrails.py tests/test_auth.py tests/test_identity_mapping.py
 
 # integration tests (require a reachable Postgres-compatible DB)
 YUGABYTEDB_URL="host=… port=… …" uv run pytest tests/

--- a/examples/oidc-auth/.env.example
+++ b/examples/oidc-auth/.env.example
@@ -1,0 +1,49 @@
+# Tutorial env file — copy to .env and source before running the MCP server.
+# All values are dev-only and matched to docker-compose.yaml + the
+# realm-export.json next to it.
+
+# --- Auth provider ---
+MCP_AUTH_PROVIDER=oidc
+MCP_BASE_URL=http://localhost:8000
+
+# Origin allowlist for DNS-rebinding defense on the HTTP transport.
+# Defaults to MCP_BASE_URL only; we additionally allow http://localhost:6274,
+# which is where MCP Inspector serves its UI when launched via `npx
+# @modelcontextprotocol/inspector`. Without this entry Inspector requests
+# get rejected with 403 "origin not allowed" and the OAuth flow fails.
+MCP_ALLOWED_ORIGINS=http://localhost:8000,http://localhost:6274
+
+# --- Generic OIDC settings (Keycloak in this tutorial) ---
+OIDC_CONFIG_URL=http://localhost:18080/realms/yb-mcp/.well-known/openid-configuration
+OIDC_CLIENT_ID=yb-mcp-server
+OIDC_CLIENT_SECRET=tutorial-secret-not-for-prod
+# OIDC_AUDIENCE=  # Leave unset for Keycloak — it doesn't require audience binding.
+
+# --- OIDC → Postgres role mapping ---
+# Which JWT claim to use as the database role identifier. For Keycloak
+# (and most providers) `email` is the natural choice. Cognito users
+# may want `sub` or a custom attribute claim.
+YB_MCP_IDENTITY_CLAIM=email
+# `strip_domain` turns `writer@yugabyte.com` → `writer` so the role name
+# is just the email local-part. Set to `none` if your role names already
+# match the raw claim value.
+YB_MCP_IDENTITY_TRANSFORM=strip_domain
+
+# --- Write tool ---
+# `run_write_query` is disabled by default (it's a destructive tool).
+# We enable it here only so the tutorial can demonstrate that GRANTs on
+# the database side still reject the wrong user even when the tool is
+# available. In production, leave this unset / false unless you have a
+# specific reason to expose writes.
+YB_MCP_ENABLE_WRITE_QUERY=true
+
+# --- YugabyteDB connection ---
+# Point this at any reachable YugabyteDB or PostgreSQL instance.
+# The connection-string user (`yugabyte` here) must have been GRANTed
+# membership in every role that OIDC users will map to — `postgres-seed.sql`
+# handles that for `writer` and `reader`.
+YUGABYTEDB_URL="host=localhost port=5433 dbname=yugabyte user=yugabyte password=yugabyte"
+
+# --- Optional ---
+YB_MCP_STATELESS_HTTP=true
+YB_LOG_LEVEL=INFO

--- a/examples/oidc-auth/README.md
+++ b/examples/oidc-auth/README.md
@@ -1,0 +1,464 @@
+# OIDC authentication tutorial — with per-user database roles
+
+This tutorial walks you through running `yugabytedb-mcp-server` behind a generic OIDC identity provider AND mapping each OIDC user to a distinct Postgres role, so the database itself enforces what each user can read or write. We use **Keycloak** (open-source, self-hosted, Docker-based) so the whole setup runs on your laptop without any third-party signup. The same configuration pattern works against Auth0, Okta, Azure AD, Google Identity, or any RFC 6749 / OIDC 1.0 compliant provider — only the connection details change.
+
+## What you'll prove by the end
+
+> Two Keycloak users (`writer@yugabyte.com`, `reader@yugabyte.com`) hit the **same MCP server, same connection pool, same `run_write_query` tool**. `writer` can INSERT into the `notes` table. `reader` cannot — the database itself rejects the write. The difference is purely the OIDC bearer token, which drives a different `SET ROLE` per request.
+
+## Architecture
+
+```
+┌──────────────────┐   1. browser OAuth   ┌──────────────────┐
+│ MCP client       │ ───────────────────► │ Keycloak         │
+│ (demo_client.py, │                      │ http://:18080    │
+│  Inspector,      │   2. Streamable HTTP │ realm: yb-mcp    │
+│  Cursor,         │ ◄───── bearer ──────►│ writer / reader  │
+│  Claude...)      │                      │                  │
+└──────────────────┘                      └──────────────────┘
+         │
+         ▼
+┌────────────────────────────────────┐         ┌──────────────────┐
+│ yugabytedb-mcp-server              │         │ YugabyteDB       │
+│ http://:8000  transport=http       │ ──SQL──►│                  │
+│ MCP_AUTH_PROVIDER=oidc             │  +SET   │  role: writer    │
+│ YB_MCP_IDENTITY_CLAIM=email        │  ROLE   │  role: reader    │
+│ YB_MCP_IDENTITY_TRANSFORM=         │         │  GRANTs decide   │
+│   strip_domain                     │         │  who can write   │
+└────────────────────────────────────┘         └──────────────────┘
+```
+
+The MCP server's `OIDCProxy` sits between your MCP client and Keycloak. Clients see a standard OAuth 2.0 surface (`/authorize`, `/token`, `/register`) at the MCP server's URL; the proxy translates those into upstream Keycloak calls. Once a token is validated, the server extracts the email claim, strips the domain, and uses the local-part (`writer` / `reader`) as the Postgres role to `SET ROLE` into for the duration of that tool call.
+
+## Prerequisites
+
+- **Docker** (Engine ≥ 20.x) — to run Keycloak
+- **`uv`** — to run the MCP server (`brew install uv`, `pip install uv`, or [docs.astral.sh/uv](https://docs.astral.sh/uv/))
+- A reachable **YugabyteDB** instance — local `yugabyted start` works fine. PostgreSQL also works; the tutorial uses `ysqlsh` for the seed step but `psql` is a drop-in substitute.
+- 10–15 minutes
+
+## Step 1 — Start Keycloak
+
+From this directory:
+
+```bash
+docker compose up -d
+```
+
+Wait ~20 seconds for Keycloak to boot and import the realm. Verify:
+
+```bash
+curl -fs http://localhost:18080/realms/yb-mcp/.well-known/openid-configuration | head -c 200
+```
+
+You should see JSON describing the issuer, authorization endpoint, token endpoint, etc.
+
+What just happened:
+- Keycloak 26 booted in dev mode on port `18080`
+- The `yb-mcp` realm was imported from `keycloak/realm-export.json`
+- A confidential client `yb-mcp-server` was registered with secret `tutorial-secret-not-for-prod`
+- **Two** test users were created:
+  - `writer@yugabyte.com` / `Writer123`
+  - `reader@yugabyte.com` / `Reader123`
+
+### View the realm in the Keycloak admin console (optional)
+
+If you want to inspect the imported realm, browse users, or look at token claims, open the Keycloak admin console:
+
+| Field | Value |
+|---|---|
+| URL | <http://localhost:18080> |
+| Username | `admin` |
+| Password | `admin` |
+
+After signing in, use the realm dropdown in the top-left to switch from **master** to **yb-mcp**. The tutorial itself doesn't require the admin console.
+
+## Step 2 — Seed the database
+
+The MCP server side of the role mapping is "extract the claim, `SET ROLE <claim>`". The database side has to actually have those roles and the right GRANTs on them. `postgres-seed.sql` does both. Run `ysqlsh` from your YugabyteDB install and pass the seed script's absolute path:
+
+```bash
+./path/to/yugabytedb/installation/bin/ysqlsh \
+    -v yb_pool_user=yugabyte \
+    -f /path/to/local/yugabytedb-mcp-server/examples/oidc-auth/postgres-seed.sql
+```
+
+Substitute the two paths to match your machine:
+
+- `./path/to/yugabytedb/installation/bin/ysqlsh` — the `ysqlsh` binary that ships with your YugabyteDB install. On Postgres-only systems, use `psql` instead — same flags.
+- `/path/to/local/yugabytedb-mcp-server/examples/oidc-auth/postgres-seed.sql` — the seed script's absolute path on your machine.
+
+Replace `yugabyte` with whichever username is in your `YUGABYTEDB_URL` if different. `ysqlsh` picks up connection details from the `YUGABYTEDB_URL` / `PG*` environment, or you can pass them inline (`-h`, `-p`, `-U`, `-d`). The script is idempotent; safe to re-run.
+
+What the seed sets up:
+
+| Object | Created with |
+|---|---|
+| Postgres role `writer` (NOLOGIN) | `CREATE ROLE writer NOLOGIN` |
+| Postgres role `reader` (NOLOGIN) | `CREATE ROLE reader NOLOGIN` |
+| Table `notes(id, body, created_at)` | `CREATE TABLE IF NOT EXISTS notes …` |
+| `writer` GRANTs | `GRANT SELECT, INSERT, UPDATE, DELETE ON notes TO writer` + sequence access |
+| `reader` GRANT | `GRANT SELECT ON notes TO reader` |
+| Pool user membership | `GRANT writer TO :"yb_pool_user"` + same for reader |
+
+### What's the "pool user" and why does membership matter?
+
+The MCP server keeps a connection pool open to YugabyteDB. The pool authenticates as **the database account inside `YUGABYTEDB_URL`** — in this tutorial that's `yugabyte`. We call that account the "pool user" for short; it's just a label, not a Keycloak or Postgres-specific term. It's the only DB identity the server *natively* has.
+
+When an OIDC user calls a tool, the server runs `SET ROLE <oidc_user>` on a pooled connection. Postgres only allows that switch if the **currently-authenticated** account (the pool user) is a member of the target role:
+
+```text
+1. Pool connects as user `yugabyte`.
+2. Tool call arrives; OIDC token says reader@yugabyte.com → role `reader`.
+3. Server runs:  SET ROLE reader
+4. Postgres checks: "Is `yugabyte` a member of role `reader`?"
+   YES (because of `GRANT reader TO yugabyte`)  → role switch succeeds
+   NO                                            → permission denied to set role "reader"
+```
+
+The `GRANT writer TO :"yb_pool_user"` / `GRANT reader TO :"yb_pool_user"` lines at the bottom of `postgres-seed.sql` are what wire that up. Without them, every tool call from a real OIDC user fails — the MCP server keeps running but can't switch roles. **Skip the membership grants and the entire role-mapping demo doesn't work.**
+
+(In some YugabyteDB / Postgres setups the default `yugabyte` user is a superuser, in which case `SET ROLE` works for any role even without an explicit GRANT. Convenient for tutorials but defeats the point in production — you'd want the pool user to be a least-privileged account whose only privileges are membership in the OIDC-mapped roles.)
+
+Confirm the seed by reading its sanity-check output: you should see the two roles listed, the five GRANTs, and two membership rows.
+
+## Step 3 — Configure the MCP server
+
+From the **repo root** (one level up from this folder):
+
+```bash
+cp examples/oidc-auth/.env.example .env
+# Edit YUGABYTEDB_URL in .env to point at the database you just seeded
+```
+
+Notable settings in `.env`:
+
+| Variable | Value | Why |
+|---|---|---|
+| `MCP_AUTH_PROVIDER` | `oidc` | Generic OIDC factory (not Cognito-specific). |
+| `OIDC_CONFIG_URL` | Keycloak's discovery URL | Lets `OIDCProxy` auto-discover authorize / token / jwks endpoints. |
+| `YB_MCP_IDENTITY_CLAIM` | `email` | JWT claim used as the role identifier. |
+| `YB_MCP_IDENTITY_TRANSFORM` | `strip_domain` | Turns `writer@yugabyte.com` → `writer`. |
+| `YB_MCP_ENABLE_WRITE_QUERY` | `true` | Enable `run_write_query` so the demo can show that DB-side GRANTs reject the wrong user. **In production, leave this unset — the write tool is disabled by default for a reason.** |
+| `MCP_ALLOWED_ORIGINS` | `http://localhost:8000,http://localhost:6274` | DNS-rebinding defense. The server rejects browser requests whose `Origin` header isn't in this list. `http://localhost:8000` is the server itself; `http://localhost:6274` is where MCP Inspector serves its UI when launched via `npx`. Without the second entry, Inspector's connect attempt in Step 5 returns 403. |
+
+Start the server:
+
+```bash
+set -a; source .env; set +a
+uv run yugabytedb-mcp --transport http
+```
+
+(Or `uvx yugabytedb-mcp-server --transport http` if you've installed the published package — both run the same entry point.)
+
+You should see in the logs:
+
+```
+[INFO] yugabytedb-mcp.auth: Creating auth provider: oidc
+[INFO] yugabytedb-mcp.auth: OIDC auth provider created (config_url=http://localhost:18080/realms/yb-mcp/.well-known/openid-configuration)
+[INFO] yugabytedb-mcp.server: Per-user SET ROLE enabled (claim=email, transform=strip_domain). ...
+[INFO] yugabytedb-mcp.server: run_write_query tool enabled
+[INFO] yugabytedb-mcp.server: Origin allowlist: http://localhost:8000
+[INFO] yugabytedb-mcp.server: WWW-Authenticate scope injection enabled (scope=openid email profile)
+INFO:     Uvicorn running on http://0.0.0.0:8000
+```
+
+Two key proof points:
+- `Per-user SET ROLE enabled (claim=email, transform=strip_domain)` confirms the role-mapping plumbing is on.
+- `run_write_query tool enabled` confirms the write tool is registered. (Without `YB_MCP_ENABLE_WRITE_QUERY=true`, the log would read `run_write_query tool disabled` and the tool wouldn't appear in `tools/list`.)
+
+Auth is now enforced. Confirm with curl:
+
+```bash
+# /ping is unauthenticated → 200
+curl -i http://localhost:8000/ping
+
+# /mcp without a token → 401 + WWW-Authenticate header
+# (note: /mcp only accepts POST/DELETE — a GET will return 405,
+#  so we send a real initialize POST here)
+curl -i -X POST http://localhost:8000/mcp \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"curl","version":"1"}}}'
+```
+
+## Step 4 — Run the one-command demo client
+
+The fastest way to see the full demo work is the bundled `demo_client.py`. It walks the full browser-based authorization-code OAuth flow — the same flow Claude Desktop, Cursor, and MCP Inspector use — and then exercises three MCP tool calls.
+
+From this directory:
+
+```bash
+uv run demo_client.py
+```
+
+The first run takes a few extra seconds while `uv` resolves and caches the script's dependencies (`httpx` and the `mcp` Python SDK, declared inline in the script header). Subsequent runs are instant.
+
+### What happens
+
+1. The script starts a local OAuth callback listener on `http://localhost:9876/callback`.
+2. It opens your browser to Keycloak's sign-in page.
+3. You enter **either** user's credentials:
+
+   | Username or email | Password | Outcome |
+   |---|---|---|
+   | `reader@yugabyte.com` | `Reader123` | Reads succeed, writes are rejected by Postgres. |
+   | `writer@yugabyte.com` | `Writer123` | Reads and writes both succeed. |
+
+4. Keycloak redirects back to the callback listener with an authorization code.
+5. The script exchanges the code for an access token, opens a Streamable HTTP MCP session against `http://localhost:8000/mcp`, and runs three demo calls.
+
+### Expected output — signed in as `reader`
+
+```
+==> Opening browser for Keycloak sign-in...
+==> Signed in as reader@yugabyte.com
+
+==> Connected to MCP server. Tools: run_read_only_query, run_write_query, summarize_database
+
+--- 1. Confirm effective database role ---
+[{"current_user": "reader", "session_user": "yugabyte", "effective_role": "reader"}]
+
+--- 2. SELECT from notes ---
+[{"id": 1, "body": "hello, world (seeded)"}, {"id": 2, "body": "reader can see this"}]
+
+--- 3. INSERT into notes as reader ---
+{"error": "permission denied for table notes"}
+```
+
+### Expected output — signed in as `writer`
+
+```
+==> Opening browser for Keycloak sign-in...
+==> Signed in as writer@yugabyte.com
+
+==> Connected to MCP server. Tools: run_read_only_query, run_write_query, summarize_database
+
+--- 1. Confirm effective database role ---
+[{"current_user": "writer", "session_user": "yugabyte", "effective_role": "writer"}]
+
+--- 2. SELECT from notes ---
+[{"id": 1, "body": "hello, world (seeded)"}, {"id": 2, "body": "reader can see this"}]
+
+--- 3. INSERT into notes as writer ---
+{"rows_affected": 1}
+```
+
+Same MCP server, same connection pool, same tool catalog. Only the OIDC bearer changes, and with it the effective Postgres role — and therefore the GRANT decision.
+
+### Re-run as the other user
+
+Just run the script again. The OAuth request includes `prompt=login`, which tells Keycloak to ignore any cached session and always show the login form — no manual logout step needed.
+
+```bash
+uv run demo_client.py
+```
+
+## Step 5 — (Optional) Same thing through MCP Inspector
+
+The MCP Inspector is a browser-based MCP client with a tool-execution UI. Step 4's `demo_client.py` already exercises the full role-mapping behaviour end-to-end; Inspector is useful if you want to poke at the tools interactively or experiment with arbitrary queries.
+
+### 5.1 Launch and connect
+
+```bash
+npx @modelcontextprotocol/inspector
+```
+
+A browser tab opens at `http://localhost:6274`. In the connection panel, set:
+
+| Field | Value |
+|---|---|
+| Transport | `Streamable HTTP` |
+| URL | `http://localhost:8000/mcp` |
+
+Click **Connect**. Inspector opens a Keycloak login tab; sign in as either user:
+
+| Username or email | Password |
+|---|---|
+| `reader@yugabyte.com` | `Reader123` |
+| `writer@yugabyte.com` | `Writer123` |
+
+Then click **Allow Access**. The **Tools** panel will list the three MCP tools (`summarize_database`, `run_read_only_query`, `run_write_query`) and you can call them with arbitrary SQL. The same role-mapping behaviour from Step 4 applies — reads work for both users; writes succeed only for `writer`.
+
+> **Troubleshooting — 403 `invalid_token` instead of the login page.** Inspector serves its UI from `http://localhost:6274`. That origin must be present in `MCP_ALLOWED_ORIGINS` or the MCP server's DNS-rebinding defense will reject Inspector's requests. The shipped `.env.example` includes it; if you're starting from a different config, add `http://localhost:6274` to `MCP_ALLOWED_ORIGINS` and restart the server.
+
+### 5.2 Disconnect properly when done
+
+Inspector's **Disconnect** button drops Inspector's stored token, but it does **not** clear the Keycloak session cookie in your browser. To fully sign out (so the next connect attempt shows the login form again):
+
+1. In Inspector, click **Disconnect**.
+2. In the same browser, visit Keycloak's logout URL:
+
+   ```
+   http://localhost:18080/realms/yb-mcp/protocol/openid-connect/logout
+   ```
+
+   Confirm the logout when prompted.
+
+If you skip step 2, clicking **Connect** again will silently sign you back in as the previous user. Steps 1 and 2 together give you a clean slate so you can sign in as the other user.
+
+## Step 6 — (Optional) The same thing via curl
+
+If you'd rather drive the server from a shell — for CI smoke tests or just to see the wire protocol — you can fetch tokens via Keycloak's **direct-grant (password) OAuth flow** and call tools with `curl`. Unlike the browser-based flow used by `demo_client.py` (Step 4) and Inspector (Step 5), the password grant trades a username/password directly for a token without any redirect. The shipped realm has `directAccessGrantsEnabled: true` on the `yb-mcp-server` client so this works out of the box. **Never enable that flag in production** — real clients should use the browser-based flow.
+
+### Fetch tokens for both users
+
+```bash
+get_token() {
+  curl -sf -X POST http://localhost:18080/realms/yb-mcp/protocol/openid-connect/token \
+    -H "Content-Type: application/x-www-form-urlencoded" \
+    -d "grant_type=password&client_id=yb-mcp-server&client_secret=tutorial-secret-not-for-prod&username=$1&password=$2&scope=openid email profile" \
+    | python3 -c "import sys,json;print(json.load(sys.stdin)['access_token'])"
+}
+WRITER_TOKEN=$(get_token writer@yugabyte.com Writer123)
+READER_TOKEN=$(get_token reader@yugabyte.com Reader123)
+```
+
+### Call tools via curl
+
+The wire format is JSON-RPC over Streamable HTTP. Three examples — the same kind of calls `demo_client.py` makes in Step 4:
+
+```bash
+# reader: who am I?
+curl -s -X POST http://localhost:8000/mcp \
+  -H "Authorization: Bearer $READER_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -d '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{
+      "name":"run_read_only_query",
+      "arguments":{"query":"SELECT current_user, session_user"}
+    }
+  }'
+
+# writer: INSERT succeeds
+curl -s -X POST http://localhost:8000/mcp \
+  -H "Authorization: Bearer $WRITER_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -d '{
+    "jsonrpc":"2.0","id":2,
+    "method":"tools/call",
+    "params":{
+      "name":"run_write_query",
+      "arguments":{"query":"INSERT INTO notes (body) VALUES ('"'"'hello from writer (curl)'"'"')"}
+    }
+  }'
+
+# reader: same INSERT, permission denied
+curl -s -X POST http://localhost:8000/mcp \
+  -H "Authorization: Bearer $READER_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -d '{
+    "jsonrpc":"2.0","id":3,
+    "method":"tools/call",
+    "params":{
+      "name":"run_write_query",
+      "arguments":{"query":"INSERT INTO notes (body) VALUES ('"'"'hello from reader (curl)'"'"')"}
+    }
+  }'
+```
+
+The first two return `rows_affected: 1` (writer) and the SELECT result (reader). The third returns `{"error": "permission denied for table notes"}` — the same database-level rejection you saw in Step 4, just dressed in JSON-RPC framing instead of script output.
+
+## How it works under the hood
+
+1. **MCP client → MCP server** — client tries to call `/mcp`, gets `401 WWW-Authenticate: Bearer ... resource_metadata="..."`.
+2. **MCP client → MCP server `/.well-known/oauth-protected-resource/mcp`** — learns the auth server is at `http://localhost:8000/`.
+3. **MCP client → MCP server `/.well-known/oauth-authorization-server`** — learns the registration, authorize, token endpoints.
+4. **MCP client → MCP server `/register`** — Dynamic Client Registration (RFC 7591); client gets a `client_id` issued by the MCP server.
+5. **MCP client → MCP server `/authorize`** — `OIDCProxy` redirects the browser to **Keycloak's** authorize endpoint with the upstream `client_id` (`yb-mcp-server`) and a callback URL pointing back at the MCP server (`/auth/callback`).
+6. **Browser → Keycloak** — user logs in as `writer` or `reader`.
+7. **Keycloak → MCP server `/auth/callback`** — Keycloak redirects with an authorization code.
+8. **MCP server → Keycloak `/token`** — `OIDCProxy` exchanges the code for an upstream access + refresh token.
+9. **MCP server → MCP client** — `OIDCProxy` mints its own JWT for the MCP client (so the client never holds the Keycloak token directly), redirects back to the client's callback URL with that token.
+10. **MCP client → MCP server `/mcp`** — calls with `Authorization: Bearer <token>`. JWT verification happens at the MCP server; tool dispatched.
+11. **MCP server `_get_db_role()` → `_conn_as_role()`** — extracts the `email` claim, strips the domain, and runs `SET ROLE <claim>` on the pooled connection before the tool's SQL. `RESET ROLE` runs in a `finally` block so the connection returns to the pool clean.
+
+The role switch lives in `src/yugabytedb_mcp_server/tools.py`:
+
+```python
+@contextmanager
+def _conn_as_role(pool, role: str | None):
+    """Acquire a connection and optionally SET ROLE for the duration."""
+    with pool.connection() as conn:
+        if role is not None:
+            with conn.cursor() as cur:
+                cur.execute(SQL("SET ROLE {}").format(Identifier(role)))
+        try:
+            yield conn
+        finally:
+            if role is not None:
+                with conn.cursor() as cur:
+                    cur.execute("RESET ROLE")
+```
+
+Role names are quoted via `psycopg.sql.Identifier`, so a JWT claim of `'; DROP TABLE notes; --` is safely escaped — it would be rejected by Postgres as a role-not-found rather than executed as SQL.
+
+## Adapting to a different OIDC provider
+
+The same MCP server config works with any OIDC IdP — only the env vars need to change:
+
+| Variable | What to set |
+|---|---|
+| `OIDC_CONFIG_URL` | URL of the provider's `.well-known/openid-configuration` |
+| `OIDC_CLIENT_ID` | Confidential client ID registered in the provider |
+| `OIDC_CLIENT_SECRET` | That client's secret |
+| `OIDC_AUDIENCE` | Optional. Set if the provider issues access tokens with an `aud` claim you want enforced |
+| `YB_MCP_IDENTITY_CLAIM` | Which JWT claim identifies the user. Defaults to `email`. Common alternatives: `preferred_username`, `sub`. |
+| `YB_MCP_IDENTITY_TRANSFORM` | `strip_domain` for email claims, `none` for everything else |
+
+The client in your provider must:
+- Be **confidential** (have a client secret)
+- Allow the **authorization_code** grant
+- Allow `client_secret_basic` or `client_secret_post` token endpoint auth
+- Allow `PKCE S256` (most providers default to this)
+- Have `http://<MCP_BASE_URL>/auth/callback` in its allowed redirect URIs (replace `<MCP_BASE_URL>` with your deployment's public URL)
+
+Provider-specific notes:
+
+- **Auth0** — set `OIDC_CONFIG_URL=https://YOUR_TENANT.us.auth0.com/.well-known/openid-configuration`. Use a "Regular Web Application" client type. Add the callback URL under "Allowed Callback URLs" in the dashboard. `email` is in the ID token by default.
+- **Okta** — set `OIDC_CONFIG_URL=https://YOUR_DOMAIN.okta.com/.well-known/openid-configuration` (or the per-app variant). Create an OIDC Web app. May need to request the `email` scope explicitly.
+- **Google Identity** — set `OIDC_CONFIG_URL=https://accounts.google.com/.well-known/openid-configuration`. Configure an "OAuth 2.0 Client ID" of type "Web application" in Google Cloud Console.
+- **Azure AD / Entra ID** — `yugabytedb-mcp-server` ships a separate `MCP_AUTH_PROVIDER=azure` mode tuned for Entra's quirks. Use that instead of the generic `oidc` mode.
+- **AWS Cognito** — same story. `MCP_AUTH_PROVIDER=cognito` handles four Cognito-specific quirks (token-endpoint scope handling, no PKCE on upstream, etc.). Use it instead of `oidc`. Cognito's default user identifier is `sub` (UUID), which is rarely what you want as a database role name — consider a custom claim mapping in the user pool.
+
+## Tearing down
+
+```bash
+docker compose down -v   # stops Keycloak and removes the volume
+```
+
+Kill the MCP server with Ctrl-C in its terminal. Remove `.env` if you don't want the dev-only credentials lying around. The Postgres roles, table, and GRANTs survive the teardown — drop them explicitly if you don't want them:
+
+```sql
+DROP TABLE IF EXISTS notes;
+REVOKE writer, reader FROM yugabyte;  -- substitute your pool user
+DROP ROLE IF EXISTS writer;
+DROP ROLE IF EXISTS reader;
+```
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| `404 Not Found` from Keycloak `/realms/yb-mcp/.well-known/openid-configuration` | Realm didn't import. Check `docker compose logs keycloak` for an import error. Often a JSON-syntax problem in `realm-export.json` after edits. |
+| MCP server fails to start with `httpx.HTTPStatusError: 500` from the OIDC config URL | Keycloak isn't ready yet. Wait ~10 more seconds and try again. |
+| 401 from `/mcp` even with a real Keycloak token | Token's `iss` claim doesn't match `OIDC_CONFIG_URL`'s issuer. Check both — they must be byte-for-byte identical. Common case: trailing slash mismatch, or HTTPS vs HTTP. |
+| Browser flow fails with `Invalid redirect URI` from Keycloak | The MCP server is sending `redirect_uri=http://...:8000/auth/callback` and the client config in Keycloak doesn't allowlist that exact URL. Edit `realm-export.json`'s `redirectUris`, restart Keycloak. |
+| Inspector says "Connected" but tool calls return 401 | Inspector cached an old token. Disconnect and reconnect — it'll re-run the OAuth flow. |
+| Inspector's connect attempt fails with `invalid_token` and server logs show `Rejected request with disallowed Origin: http://localhost:6274` | Inspector's UI origin (`http://localhost:6274`) isn't in `MCP_ALLOWED_ORIGINS`. Add it (`MCP_ALLOWED_ORIGINS=http://localhost:8000,http://localhost:6274`) and restart the MCP server. The shipped `.env.example` already does this. |
+| `ERROR: role "reader" does not exist` from a tool call | Seed SQL wasn't run, or was run against the wrong database. Re-run `ysqlsh -v yb_pool_user=… -f postgres-seed.sql` against the same DB the MCP server is configured to use. |
+| `ERROR: permission denied to set role "reader"` | Pool user wasn't granted membership in the target role. Run `GRANT reader TO <pool_user>;` (or just re-run the seed script). |
+| `run_write_query` not in `tools/list` even though I set `YB_MCP_ENABLE_WRITE_QUERY=true` | The env var didn't make it into the server process. Check the startup logs — you should see `run_write_query tool enabled`. If it says `disabled`, you sourced `.env` after starting the server, or the variable name is mistyped. |
+
+## See also
+
+- **Generic OIDC factory**: `src/yugabytedb_mcp_server/auth.py`, function `_create_oidc()`
+- **Role switch implementation**: `src/yugabytedb_mcp_server/tools.py`, functions `_get_db_role()` and `_conn_as_role()`
+- **Write-tool gate**: `src/yugabytedb_mcp_server/server.py`, in `_register_tools()`
+- **FastMCP OIDCProxy docs**: <https://gofastmcp.com/servers/auth/oidc-proxy>
+- Top-level repo README for non-auth-related setup (database connection, tools, etc.)

--- a/examples/oidc-auth/demo_client.py
+++ b/examples/oidc-auth/demo_client.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#   "httpx",
+#   "mcp>=1.2",
+# ]
+# ///
+"""One-command MCP client for the OIDC tutorial.
+
+Drives `yugabytedb-mcp-server` end-to-end using the same browser-based
+authorization-code OAuth flow that real MCP clients (Claude Desktop,
+Cursor, MCP Inspector) use. No GUI, no Inspector — just one Python
+script that opens the browser for sign-in and then exercises the tools.
+
+Run:
+
+    uv run demo_client.py
+
+The script opens your browser to Keycloak's sign-in page. Enter EITHER
+user:
+
+    reader@yugabyte.com / Reader123    (reads succeed, writes denied)
+    writer@yugabyte.com / Writer123    (reads and writes both succeed)
+
+After sign-in, the script opens an MCP session against the running
+server and runs three demo calls.
+
+To try the other user, simply re-run the script. The OAuth request
+includes `prompt=login`, which tells Keycloak to ignore any cached
+session and always show the login form.
+
+Prerequisites: Keycloak (Step 1), the seed script (Step 2), and the
+MCP server (Step 3) all up and running. The shipped realm includes
+`http://localhost:9876/callback` as a valid redirect URI for the
+script's local OAuth callback listener.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import http.server
+import json
+import secrets
+import sys
+import threading
+import urllib.parse
+import webbrowser
+
+import httpx
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+
+KEYCLOAK_AUTHORIZE_URL = (
+    "http://localhost:18080/realms/yb-mcp/protocol/openid-connect/auth"
+)
+KEYCLOAK_TOKEN_URL = (
+    "http://localhost:18080/realms/yb-mcp/protocol/openid-connect/token"
+)
+CLIENT_ID = "yb-mcp-server"
+CLIENT_SECRET = "tutorial-secret-not-for-prod"
+MCP_URL = "http://localhost:8000/mcp"
+CALLBACK_HOST = "127.0.0.1"
+CALLBACK_PORT = 9876
+REDIRECT_URI = f"http://localhost:{CALLBACK_PORT}/callback"
+
+_received: dict[str, str | None] = {"code": None, "state": None, "error": None}
+
+
+class _CallbackHandler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):  # noqa: N802
+        params = urllib.parse.parse_qs(urllib.parse.urlparse(self.path).query)
+        _received["code"] = (params.get("code") or [None])[0]
+        _received["state"] = (params.get("state") or [None])[0]
+        _received["error"] = (params.get("error") or [None])[0]
+        body = (
+            "<html><body style='font-family: sans-serif; max-width: 480px;"
+            " margin: 4em auto; color: #202124;'>"
+            "<h2>Signed in.</h2>"
+            "<p>You can close this tab and return to the terminal.</p>"
+            "</body></html>"
+        )
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.end_headers()
+        self.wfile.write(body.encode("utf-8"))
+
+    def log_message(self, *args, **kwargs):  # silence default access log
+        pass
+
+
+def authorization_code_flow() -> str:
+    """Drive the auth-code-with-PKCE flow and return the access token."""
+    code_verifier = secrets.token_urlsafe(64)
+    code_challenge = (
+        base64.urlsafe_b64encode(hashlib.sha256(code_verifier.encode()).digest())
+        .rstrip(b"=")
+        .decode("ascii")
+    )
+    state = secrets.token_urlsafe(16)
+
+    server = http.server.HTTPServer(
+        (CALLBACK_HOST, CALLBACK_PORT), _CallbackHandler
+    )
+    listener = threading.Thread(target=server.handle_request, daemon=True)
+    listener.start()
+
+    params = {
+        "client_id": CLIENT_ID,
+        "response_type": "code",
+        "redirect_uri": REDIRECT_URI,
+        "scope": "openid email profile",
+        "state": state,
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+        "prompt": "login",
+    }
+    authorize_url = f"{KEYCLOAK_AUTHORIZE_URL}?{urllib.parse.urlencode(params)}"
+
+    print("==> Opening browser for Keycloak sign-in...")
+    print(f"    (if your browser does not open, visit:\n     {authorize_url}\n    )")
+    webbrowser.open(authorize_url)
+
+    listener.join(timeout=300)
+    server.server_close()
+
+    if _received["error"]:
+        sys.exit(f"Keycloak returned an error: {_received['error']}")
+    if not _received["code"]:
+        sys.exit("Timed out waiting for the OAuth callback.")
+    if _received["state"] != state:
+        sys.exit("State mismatch — possible CSRF.")
+
+    with httpx.Client(timeout=10) as http_:
+        r = http_.post(
+            KEYCLOAK_TOKEN_URL,
+            data={
+                "grant_type": "authorization_code",
+                "code": _received["code"],
+                "redirect_uri": REDIRECT_URI,
+                "client_id": CLIENT_ID,
+                "client_secret": CLIENT_SECRET,
+                "code_verifier": code_verifier,
+            },
+        )
+    if r.status_code != 200:
+        sys.exit(f"Token exchange failed ({r.status_code}): {r.text}")
+    return r.json()["access_token"]
+
+
+def email_from_token(access_token: str) -> str:
+    payload_b64 = access_token.split(".")[1]
+    payload_b64 += "=" * (-len(payload_b64) % 4)
+    claims = json.loads(base64.urlsafe_b64decode(payload_b64))
+    return claims.get("email") or claims.get("preferred_username") or "<unknown>"
+
+
+def render(result) -> None:
+    for block in result.content:
+        text = getattr(block, "text", None)
+        if text is None:
+            continue
+        try:
+            print(json.dumps(json.loads(text), indent=2))
+        except (json.JSONDecodeError, TypeError):
+            print(text)
+
+
+async def run_mcp(token: str, signed_in_as: str) -> None:
+    user_key = signed_in_as.split("@", 1)[0]
+    headers = {"Authorization": f"Bearer {token}"}
+    async with streamablehttp_client(MCP_URL, headers=headers) as (
+        read_stream,
+        write_stream,
+        _,
+    ):
+        async with ClientSession(read_stream, write_stream) as session:
+            await session.initialize()
+            tools = await session.list_tools()
+            tool_names = sorted(t.name for t in tools.tools)
+            print(f"==> Connected to MCP server. Tools: {', '.join(tool_names)}\n")
+
+            print("--- 1. Confirm effective database role ---")
+            render(
+                await session.call_tool(
+                    "run_read_only_query",
+                    {
+                        "query": (
+                            "SELECT current_user, session_user, "
+                            "current_setting('role') AS effective_role"
+                        )
+                    },
+                )
+            )
+
+            print("\n--- 2. SELECT from notes ---")
+            render(
+                await session.call_tool(
+                    "run_read_only_query",
+                    {"query": "SELECT id, body FROM notes ORDER BY id"},
+                )
+            )
+
+            print(f"\n--- 3. INSERT into notes as {user_key} ---")
+            render(
+                await session.call_tool(
+                    "run_write_query",
+                    {
+                        "query": (
+                            "INSERT INTO notes (body) VALUES "
+                            f"('hello from {user_key} (demo_client)')"
+                        )
+                    },
+                )
+            )
+
+
+def main() -> None:
+    token = authorization_code_flow()
+    signed_in_as = email_from_token(token)
+    print(f"==> Signed in as {signed_in_as}\n")
+    asyncio.run(run_mcp(token, signed_in_as))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/oidc-auth/docker-compose.yaml
+++ b/examples/oidc-auth/docker-compose.yaml
@@ -1,0 +1,33 @@
+# Local Keycloak instance for the OIDC tutorial.
+#
+# Boots a single Keycloak container, imports the pre-configured `yb-mcp` realm
+# from ./keycloak/realm-export.json (which includes one confidential client
+# named `yb-mcp-server` and one test user `demo`/`Demo123!`).
+#
+# The Keycloak Admin Console is at http://localhost:18080 with admin/admin.
+# Tutorial users should NOT need to touch the console — the realm is
+# pre-provisioned. The credentials are intentionally dev-only.
+#
+# Start with:    docker compose up -d
+# Stop with:     docker compose down
+# Reset state:   docker compose down -v
+
+services:
+  keycloak:
+    image: quay.io/keycloak/keycloak:26.0
+    container_name: yb-mcp-keycloak
+    environment:
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
+    ports:
+      - "18080:8080"
+    volumes:
+      - ./keycloak:/opt/keycloak/data/import:ro
+    command:
+      - start-dev
+      - --import-realm
+    healthcheck:
+      test: ["CMD-SHELL", "exec 3<>/dev/tcp/127.0.0.1/8080 && echo -e 'GET /realms/yb-mcp/.well-known/openid-configuration HTTP/1.0\\r\\n\\r\\n' >&3 && head -1 <&3 | grep -q 200"]
+      interval: 5s
+      timeout: 3s
+      retries: 30

--- a/examples/oidc-auth/keycloak/realm-export.json
+++ b/examples/oidc-auth/keycloak/realm-export.json
@@ -1,0 +1,80 @@
+{
+  "realm": "yb-mcp",
+  "enabled": true,
+  "sslRequired": "none",
+  "registrationAllowed": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": false,
+  "editUsernameAllowed": false,
+  "bruteForceProtected": false,
+  "accessTokenLifespan": 3600,
+  "clients": [
+    {
+      "clientId": "yb-mcp-server",
+      "name": "YugabyteDB MCP Server",
+      "description": "Confidential OAuth client used by the MCP server's OIDCProxy",
+      "enabled": true,
+      "publicClient": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "tutorial-secret-not-for-prod",
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "redirectUris": [
+        "http://localhost:8000/auth/callback",
+        "http://localhost:8000/*",
+        "http://localhost:9876/callback"
+      ],
+      "webOrigins": [
+        "http://localhost:8000"
+      ],
+      "attributes": {
+        "pkce.code.challenge.method": "S256"
+      },
+      "defaultClientScopes": [
+        "openid",
+        "email",
+        "profile"
+      ]
+    }
+  ],
+  "users": [
+    {
+      "username": "writer",
+      "email": "writer@yugabyte.com",
+      "firstName": "Write",
+      "lastName": "User",
+      "enabled": true,
+      "emailVerified": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Writer123",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "default-roles-yb-mcp"
+      ]
+    },
+    {
+      "username": "reader",
+      "email": "reader@yugabyte.com",
+      "firstName": "Read",
+      "lastName": "Only",
+      "enabled": true,
+      "emailVerified": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Reader123",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "default-roles-yb-mcp"
+      ]
+    }
+  ]
+}

--- a/examples/oidc-auth/postgres-seed.sql
+++ b/examples/oidc-auth/postgres-seed.sql
@@ -1,0 +1,95 @@
+-- examples/oidc-auth/postgres-seed.sql
+--
+-- Seeds the demo database for the OIDC-to-Postgres role mapping tutorial.
+-- Creates two roles (`writer`, `reader`) matching the Keycloak users
+-- (writer@yugabyte.com / reader@yugabyte.com) after the strip_domain
+-- transform. Creates a `notes` table with row-level GRANTs that enforce
+-- the behaviour the tutorial demonstrates:
+--
+--   writer  -> can SELECT and INSERT/UPDATE/DELETE on notes
+--   reader  -> can SELECT only
+--
+-- IMPORTANT — the pool user
+--
+-- The MCP server connects with the database user from YUGABYTEDB_URL
+-- (call this the "pool user"). The per-request SET ROLE only works if
+-- the pool user has been granted membership in the target role. The
+-- last block of this script does that automatically using
+-- :"yb_pool_user", which ysqlsh/psql substitutes from a -v flag:
+--
+--   ysqlsh "$YUGABYTEDB_URL" -v yb_pool_user=yugabyte -f postgres-seed.sql
+--
+-- Substitute `yugabyte` with whichever user appears in your YUGABYTEDB_URL.
+-- The script is idempotent; safe to re-run.
+
+\set ON_ERROR_STOP on
+
+-- 1. Roles. Both are NOLOGIN — they exist only to be SET ROLE'd into.
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'writer') THEN
+        CREATE ROLE writer NOLOGIN;
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'reader') THEN
+        CREATE ROLE reader NOLOGIN;
+    END IF;
+END $$;
+
+-- 2. Demo table. IF NOT EXISTS keeps re-runs cheap.
+CREATE TABLE IF NOT EXISTS notes (
+    id    SERIAL PRIMARY KEY,
+    body  TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- A couple of seed rows so SELECT returns something on the first run.
+-- (Idempotent via the NOT EXISTS guard.)
+INSERT INTO notes (body)
+SELECT 'hello, world (seeded)'
+WHERE NOT EXISTS (SELECT 1 FROM notes);
+
+INSERT INTO notes (body)
+SELECT 'reader can see this'
+WHERE (SELECT COUNT(*) FROM notes) < 2;
+
+-- 3. GRANTs.
+--
+-- We grant on the table itself + on the sequence backing the SERIAL,
+-- because writes need both. SELECT is enough for reads.
+GRANT SELECT ON notes TO reader;
+GRANT SELECT, INSERT, UPDATE, DELETE ON notes TO writer;
+GRANT USAGE, SELECT, UPDATE ON SEQUENCE notes_id_seq TO writer;
+
+-- 4. Membership for the pool user.
+--
+-- Without this, `SET ROLE reader` returns:
+--   ERROR: permission denied to set role "reader"
+--
+-- The pool user must be a member of every role it will SET ROLE into.
+GRANT writer TO :"yb_pool_user";
+GRANT reader TO :"yb_pool_user";
+
+-- 5. Sanity check — print what we just set up so the tutorial reader can
+-- see the seed worked.
+\echo
+\echo '=== Roles ==='
+SELECT rolname FROM pg_roles WHERE rolname IN ('writer', 'reader') ORDER BY rolname;
+
+\echo
+\echo '=== GRANTs on notes ==='
+SELECT grantee, privilege_type
+FROM information_schema.table_privileges
+WHERE table_name = 'notes' AND grantee IN ('writer', 'reader')
+ORDER BY grantee, privilege_type;
+
+\echo
+\echo '=== Membership ==='
+SELECT r.rolname AS member, g.rolname AS in_group
+FROM pg_auth_members m
+JOIN pg_roles r ON r.oid = m.member
+JOIN pg_roles g ON g.oid = m.roleid
+WHERE g.rolname IN ('writer', 'reader')
+ORDER BY g.rolname, r.rolname;
+
+\echo
+\echo 'Seed complete.'

--- a/src/yugabytedb_mcp_server/server.py
+++ b/src/yugabytedb_mcp_server/server.py
@@ -37,6 +37,8 @@ class ServerConfig:
     require_where_on_delete: bool
     auth_provider: str | None
     enable_write_query: bool
+    identity_claim: str
+    identity_transform: str
 
 
 def normalize_pem(pem: str) -> str:
@@ -133,8 +135,20 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[dict]:
         guardrail_config.require_where_on_update,
         guardrail_config.require_where_on_delete,
     )
+    if CONFIG.auth_provider:
+        logger.info(
+            "Per-user SET ROLE enabled (claim=%s, transform=%s). "
+            "The pool user must be a superuser or have membership in target roles.",
+            CONFIG.identity_claim, CONFIG.identity_transform,
+        )
+
     try:
-        yield {"pool": pool, "guardrail_config": guardrail_config}
+        yield {
+            "pool": pool,
+            "guardrail_config": guardrail_config,
+            "identity_claim": CONFIG.identity_claim,
+            "identity_transform": CONFIG.identity_transform,
+        }
     finally:
         logger.info("Closing database connections")
         pool.close()
@@ -208,6 +222,19 @@ def parse_config() -> ServerConfig:
         default=os.environ.get("MCP_AUTH_PROVIDER"),
         help="Auth provider for the MCP server: 'cognito' or 'oidc'. Leave unset to disable auth (env: MCP_AUTH_PROVIDER)",
     )
+    parser.add_argument(
+        "--identity-claim",
+        default=os.environ.get("YB_MCP_IDENTITY_CLAIM", "email"),
+        help="JWT claim to use as the DB role identifier (env: YB_MCP_IDENTITY_CLAIM, default: email)",
+    )
+    parser.add_argument(
+        "--identity-transform",
+        default=os.environ.get("YB_MCP_IDENTITY_TRANSFORM", "none"),
+        choices=["none", "strip_domain"],
+        help="Transform applied to the identity claim before using as DB role: "
+             "'none' (use as-is) or 'strip_domain' (strip @... from email) "
+             "(env: YB_MCP_IDENTITY_TRANSFORM, default: none)",
+    )
 
     args = parser.parse_args()
     return ServerConfig(
@@ -223,6 +250,8 @@ def parse_config() -> ServerConfig:
         require_where_on_delete=args.require_where_on_delete,
         auth_provider=args.mcp_auth_provider,
         enable_write_query=args.enable_write_query,
+        identity_claim=args.identity_claim,
+        identity_transform=args.identity_transform,
     )
 
 

--- a/src/yugabytedb_mcp_server/tools.py
+++ b/src/yugabytedb_mcp_server/tools.py
@@ -44,11 +44,19 @@ def _apply_transform(value: str, transform: str) -> str:
     return value
 
 
+class IdentityError(Exception):
+    """Raised when an authenticated token lacks the required identity claim."""
+
+
 def _get_db_role(ctx: Context) -> str | None:
     """Extract the database role from the authenticated user's OIDC token.
 
     Returns None when auth is disabled or no token is present (the pool's
     default credentials will be used).
+
+    Raises IdentityError when a token IS present but the required claim is
+    missing — falling back to pool credentials in this case would be a
+    privilege escalation.
     """
     try:
         token = get_access_token()
@@ -64,12 +72,10 @@ def _get_db_role(ctx: Context) -> str | None:
 
     claim_value = token.claims.get(claim_name)
     if not claim_value:
-        logger.warning(
-            "Token present but claim %r is missing or empty; "
-            "falling back to pool credentials",
-            claim_name,
+        raise IdentityError(
+            f"Token present but required claim {claim_name!r} is missing or empty. "
+            f"Cannot determine database role for authenticated user."
         )
-        return None
 
     role = _apply_transform(str(claim_value), transform)
     logger.debug("Resolved DB role %r from claim %r=%r", role, claim_name, claim_value)
@@ -113,7 +119,12 @@ def summarize_database(ctx: Context, schema: str = "public") -> List[Dict[str, A
     logger.info("summarize_database called (schema=%s)", schema)
     summary: List[Dict[str, Any]] = []
     pool = ctx.request_context.lifespan_context["pool"]
-    role = _get_db_role(ctx)
+
+    try:
+        role = _get_db_role(ctx)
+    except IdentityError as e:
+        logger.error("Identity resolution failed: %s", e)
+        return [{"error": str(e)}]
 
     with _conn_as_role(pool, role) as conn:
         logger.debug("Acquired connection from pool for summarize_database")
@@ -190,7 +201,12 @@ def run_read_only_query(ctx: Context, query: str) -> str:
     logger.info("run_read_only_query called")
     logger.debug("Query: %s", query)
     pool = ctx.request_context.lifespan_context["pool"]
-    role = _get_db_role(ctx)
+
+    try:
+        role = _get_db_role(ctx)
+    except IdentityError as e:
+        logger.error("Identity resolution failed: %s", e)
+        return json.dumps({"error": str(e)})
 
     with _conn_as_role(pool, role) as conn:
         logger.debug("Acquired connection from pool for run_read_only_query")
@@ -245,7 +261,11 @@ def run_write_query(ctx: Context, query: str) -> str:
         logger.warning("Query blocked by guardrail: %s", e)
         return json.dumps({"error": str(e), "blocked_by_guardrail": True})
 
-    role = _get_db_role(ctx)
+    try:
+        role = _get_db_role(ctx)
+    except IdentityError as e:
+        logger.error("Identity resolution failed: %s", e)
+        return json.dumps({"error": str(e)})
 
     with _conn_as_role(pool, role) as conn:
         logger.debug("Acquired connection from pool for run_write_query")

--- a/src/yugabytedb_mcp_server/tools.py
+++ b/src/yugabytedb_mcp_server/tools.py
@@ -4,27 +4,97 @@ All three tools acquire a connection from the lifespan-owned ConnectionPool,
 run their query, and return JSON. Read tools wrap the query in
 `BEGIN READ ONLY ... ROLLBACK` for transaction-level enforcement. Write tool
 runs through the guardrail blocklist before executing.
+
+When OIDC auth is active, each tool call wraps its SQL execution in
+SET ROLE / RESET ROLE so the query runs under the database role corresponding
+to the authenticated user's identity.
 """
 
 import json
 import logging
+from contextlib import contextmanager
 from typing import Any, Dict, List
 
 from fastmcp import Context
+from fastmcp.server.dependencies import get_access_token
+from psycopg.sql import SQL, Identifier
 
 from .guardrails import GuardrailConfig, QueryBlockedError, validate_write_query
 
 logger = logging.getLogger("yugabytedb-mcp.tools")
 
 
-def _execute(cur, query: str, params: tuple | None = None) -> None:
-    """Thin execute wrapper that logs at DEBUG before running."""
+def _execute(cur, query, params: tuple | None = None) -> None:
+    """Thin execute wrapper that logs at DEBUG before running.
+
+    `query` may be a plain string or a psycopg.sql.Composed/SQL object.
+    """
     if params is not None:
-        logger.debug("SQL: %s | params=%r", query.strip(), params)
+        logger.debug("SQL: %s | params=%r", query, params)
         cur.execute(query, params)
     else:
-        logger.debug("SQL: %s", query.strip())
+        logger.debug("SQL: %s", query)
         cur.execute(query)
+
+
+def _apply_transform(value: str, transform: str) -> str:
+    """Apply a named transform to a claim value to derive a DB role name."""
+    if transform == "strip_domain":
+        return value.split("@", 1)[0]
+    return value
+
+
+def _get_db_role(ctx: Context) -> str | None:
+    """Extract the database role from the authenticated user's OIDC token.
+
+    Returns None when auth is disabled or no token is present (the pool's
+    default credentials will be used).
+    """
+    try:
+        token = get_access_token()
+    except RuntimeError:
+        return None
+
+    if token is None:
+        return None
+
+    lifespan = ctx.request_context.lifespan_context
+    claim_name = lifespan.get("identity_claim", "email")
+    transform = lifespan.get("identity_transform", "none")
+
+    claim_value = token.claims.get(claim_name)
+    if not claim_value:
+        logger.warning(
+            "Token present but claim %r is missing or empty; "
+            "falling back to pool credentials",
+            claim_name,
+        )
+        return None
+
+    role = _apply_transform(str(claim_value), transform)
+    logger.debug("Resolved DB role %r from claim %r=%r", role, claim_name, claim_value)
+    return role
+
+
+@contextmanager
+def _conn_as_role(pool, role: str | None):
+    """Acquire a connection and optionally SET ROLE for the duration.
+
+    If `role` is not None, executes SET ROLE before yielding and RESET ROLE
+    in the finally block so the connection is returned to the pool clean.
+    """
+    with pool.connection() as conn:
+        if role is not None:
+            with conn.cursor() as cur:
+                cur.execute(SQL("SET ROLE {}").format(Identifier(role)))
+            logger.debug("SET ROLE %s", role)
+        try:
+            yield conn
+        finally:
+            if role is not None:
+                with conn.cursor() as cur:
+                    cur.execute("RESET ROLE")
+                logger.debug("RESET ROLE")
 
 
 def summarize_database(ctx: Context, schema: str = "public") -> List[Dict[str, Any]]:
@@ -43,8 +113,9 @@ def summarize_database(ctx: Context, schema: str = "public") -> List[Dict[str, A
     logger.info("summarize_database called (schema=%s)", schema)
     summary: List[Dict[str, Any]] = []
     pool = ctx.request_context.lifespan_context["pool"]
+    role = _get_db_role(ctx)
 
-    with pool.connection() as conn:
+    with _conn_as_role(pool, role) as conn:
         logger.debug("Acquired connection from pool for summarize_database")
         with conn.cursor() as cur:
             try:
@@ -119,8 +190,9 @@ def run_read_only_query(ctx: Context, query: str) -> str:
     logger.info("run_read_only_query called")
     logger.debug("Query: %s", query)
     pool = ctx.request_context.lifespan_context["pool"]
+    role = _get_db_role(ctx)
 
-    with pool.connection() as conn:
+    with _conn_as_role(pool, role) as conn:
         logger.debug("Acquired connection from pool for run_read_only_query")
         with conn.cursor() as cur:
             try:
@@ -173,7 +245,9 @@ def run_write_query(ctx: Context, query: str) -> str:
         logger.warning("Query blocked by guardrail: %s", e)
         return json.dumps({"error": str(e), "blocked_by_guardrail": True})
 
-    with pool.connection() as conn:
+    role = _get_db_role(ctx)
+
+    with _conn_as_role(pool, role) as conn:
         logger.debug("Acquired connection from pool for run_write_query")
         with conn.cursor() as cur:
             try:

--- a/tests/test_identity_mapping.py
+++ b/tests/test_identity_mapping.py
@@ -1,0 +1,98 @@
+"""Unit tests for OIDC identity → DB role mapping logic.
+
+No database or MCP session required — these test the pure extraction and
+transform functions in tools.py.
+"""
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from yugabytedb_mcp_server.tools import _apply_transform, _get_db_role, IdentityError
+
+
+# ---------------------------------------------------------------------------
+# _apply_transform
+# ---------------------------------------------------------------------------
+
+class TestApplyTransform:
+    def test_none_passthrough(self):
+        assert _apply_transform("alice@example.com", "none") == "alice@example.com"
+
+    def test_strip_domain(self):
+        assert _apply_transform("alice@example.com", "strip_domain") == "alice"
+
+    def test_strip_domain_no_at_sign(self):
+        assert _apply_transform("alice", "strip_domain") == "alice"
+
+    def test_strip_domain_multiple_at_signs(self):
+        assert _apply_transform("user@sub@example.com", "strip_domain") == "user"
+
+    def test_unknown_transform_passes_through(self):
+        assert _apply_transform("alice@example.com", "unknown") == "alice@example.com"
+
+
+# ---------------------------------------------------------------------------
+# _get_db_role
+# ---------------------------------------------------------------------------
+
+def _make_ctx(identity_claim="email", identity_transform="none"):
+    """Create a minimal mock Context with lifespan_context."""
+    ctx = MagicMock()
+    ctx.request_context.lifespan_context = {
+        "identity_claim": identity_claim,
+        "identity_transform": identity_transform,
+    }
+    return ctx
+
+
+def _make_access_token(claims: dict):
+    """Create a mock AccessToken with the given claims."""
+    token = MagicMock()
+    token.claims = claims
+    return token
+
+
+class TestGetDbRole:
+    @patch("yugabytedb_mcp_server.tools.get_access_token")
+    def test_email_claim_no_transform(self, mock_get_token):
+        mock_get_token.return_value = _make_access_token({"email": "alice@example.com"})
+        ctx = _make_ctx(identity_claim="email", identity_transform="none")
+        assert _get_db_role(ctx) == "alice@example.com"
+
+    @patch("yugabytedb_mcp_server.tools.get_access_token")
+    def test_email_claim_strip_domain(self, mock_get_token):
+        mock_get_token.return_value = _make_access_token({"email": "alice@example.com"})
+        ctx = _make_ctx(identity_claim="email", identity_transform="strip_domain")
+        assert _get_db_role(ctx) == "alice"
+
+    @patch("yugabytedb_mcp_server.tools.get_access_token")
+    def test_sub_claim(self, mock_get_token):
+        mock_get_token.return_value = _make_access_token({"sub": "user-uuid-123"})
+        ctx = _make_ctx(identity_claim="sub", identity_transform="none")
+        assert _get_db_role(ctx) == "user-uuid-123"
+
+    @patch("yugabytedb_mcp_server.tools.get_access_token")
+    def test_preferred_username_claim(self, mock_get_token):
+        mock_get_token.return_value = _make_access_token({"preferred_username": "bob"})
+        ctx = _make_ctx(identity_claim="preferred_username", identity_transform="none")
+        assert _get_db_role(ctx) == "bob"
+
+    @patch("yugabytedb_mcp_server.tools.get_access_token")
+    def test_no_token_returns_none(self, mock_get_token):
+        mock_get_token.return_value = None
+        ctx = _make_ctx()
+        assert _get_db_role(ctx) is None
+
+    @patch("yugabytedb_mcp_server.tools.get_access_token")
+    def test_missing_claim_raises_identity_error(self, mock_get_token):
+        """When a token is present but the required claim is missing, raise
+        IdentityError rather than falling back to pool credentials."""
+        mock_get_token.return_value = _make_access_token({"sub": "123"})
+        ctx = _make_ctx(identity_claim="email", identity_transform="none")
+        with pytest.raises(IdentityError, match="email"):
+            _get_db_role(ctx)
+
+    @patch("yugabytedb_mcp_server.tools.get_access_token", side_effect=RuntimeError("no context"))
+    def test_runtime_error_returns_none(self, mock_get_token):
+        ctx = _make_ctx()
+        assert _get_db_role(ctx) is None


### PR DESCRIPTION
## Summary

- Per-user `SET ROLE` based on the OIDC identity claim. The JWT `email` claim is extracted, optionally transformed (e.g., `strip_domain`), and the resulting identifier becomes the Postgres role for the duration of the tool call. Implemented via `_conn_as_role()` in `tools.py` with role names quoted via `psycopg.sql.Identifier`.
- Adds `examples/oidc-auth/` — a self-contained Keycloak-based tutorial that walks through role mapping end-to-end (`docker-compose.yaml`, realm export, postgres seed, `demo_client.py`, README).

## Test plan

- [x] Verify Keycloak boots and the realm imports cleanly
- [x] Run `postgres-seed.sql` against a local YugabyteDB and confirm roles, GRANTs, and membership rows
- [x] Run the MCP server with `MCP_AUTH_PROVIDER=oidc` and `YB_MCP_IDENTITY_CLAIM=email`
- [x] Run `demo_client.py` once as `reader` (reads succeed, write rejected) and once as `writer` (both succeed)

Tutorial steps documentation: https://docs.google.com/document/d/15D0Dv0OYShKlXDHhDxnZEubEol4Q9g5Yhu8-BFd7fZQ/edit?usp=sharing