### PR TITLE
Unified SQL guardrail + read-tool safety fixes (DB-22129/22172/22131/22157/22203)

### DIFF
--- a/src/yugabytedb_mcp_server/guardrails.py
+++ b/src/yugabytedb_mcp_server/guardrails.py
@@ -129,6 +129,22 @@ _BLOCKED_FUNCTIONS: frozenset[str] = frozenset({
 })
 
 
+# Privileged catalog tables/views blocked in any context. Reading these
+# discloses credentials (pg_authid.rolpassword, pg_shadow.passwd,
+# pg_user_mappings.umoptions) or raw statistics that can leak data
+# distributions (pg_statistic). Matched against bare Name tokens; string
+# literals and double-quoted identifiers are not Name tokens, so
+# `SELECT 'pg_authid' AS x` and `SELECT "pg_authid" AS c` do NOT match.
+# Schema-qualified references (`pg_catalog.pg_authid`) match because sqlparse
+# emits `pg_authid` as its own Name token.
+_BLOCKED_TABLES: frozenset[str] = frozenset({
+    "pg_authid",
+    "pg_shadow",
+    "pg_user_mappings",
+    "pg_statistic",
+})
+
+
 def _is_keyword_token(tok) -> bool:
     """True if the token's ttype is Token.Keyword or any subtype
     (Keyword.DDL, Keyword.DML, Keyword.DCL, Keyword.CTE)."""
@@ -215,6 +231,13 @@ def _check_blocked_ast(stmt: Statement) -> None:
                     nxt = tokens[i + 1]
                     if _is_punctuation(nxt) and nxt.value == "(":
                         raise QueryBlockedError(f"{name} is not allowed")
+            # Privileged-catalog detection: bare Name match against
+            # _BLOCKED_TABLES. No `(` gate — the reference isn't a function
+            # call. False-positive risk (a user column named `pg_authid` etc.)
+            # is theoretical and acceptable for a security guard against
+            # credential/statistics disclosure.
+            elif name in _BLOCKED_TABLES:
+                raise QueryBlockedError(f"Access to {name} is not allowed")
 
 
 def _count_values_rows(sql: str) -> int | None:

--- a/src/yugabytedb_mcp_server/guardrails.py
+++ b/src/yugabytedb_mcp_server/guardrails.py
@@ -8,7 +8,7 @@ logger = logging.getLogger("yugabytedb-mcp.guardrails")
 
 
 class QueryBlockedError(Exception):
-    """Raised when a write query is rejected by a guardrail check."""
+    """Raised when a query is rejected by a guardrail check."""
     pass
 
 
@@ -39,7 +39,12 @@ _BLOCKED_PATTERNS: list[tuple[re.Pattern, str]] = [
     # Filesystem access / arbitrary code execution
     (re.compile(r"\bCOPY\b.+\b(TO|FROM)\b", re.I | re.S), "COPY TO/FROM is not allowed"),
     (re.compile(r"\bLOAD\s+", re.I), "LOAD is not allowed"),
-    (re.compile(r"\bDO\s+\$", re.I), "Anonymous code blocks (DO $$) are not allowed"),
+    # Match anonymous code blocks: bare `DO $$…$$` AND `DO LANGUAGE plpgsql $$…$$`.
+    # The pre-match _strip_strings pass replaces dollar-quoted bodies with `''`,
+    # so the bare `DO $$…$$` case becomes `DO ''` here — include that shape
+    # explicitly. The LANGUAGE form still parses as `DO LANGUAGE plpgsql ''`.
+    (re.compile(r"\bDO\s+(?:\$|LANGUAGE\b|'')", re.I),
+     "Anonymous code blocks (DO) are not allowed"),
     (re.compile(r"\bCREATE\s+EXTENSION\b", re.I), "CREATE EXTENSION is not allowed"),
 
     # Server configuration
@@ -49,13 +54,20 @@ _BLOCKED_PATTERNS: list[tuple[re.Pattern, str]] = [
     # Dangerous built-in functions
     (re.compile(r"\bpg_sleep\b", re.I), "pg_sleep is not allowed"),
     (re.compile(r"\bpg_read_file\b", re.I), "pg_read_file is not allowed"),
+    (re.compile(r"\bpg_read_binary_file\b", re.I), "pg_read_binary_file is not allowed"),
     (re.compile(r"\bpg_write_file\b", re.I), "pg_write_file is not allowed"),
+    (re.compile(r"\bpg_ls_dir\b", re.I), "pg_ls_dir is not allowed"),
     (re.compile(r"\blo_import\b", re.I), "lo_import is not allowed"),
     (re.compile(r"\blo_export\b", re.I), "lo_export is not allowed"),
     (re.compile(r"\bdblink\b", re.I), "dblink is not allowed"),
 
-    # Schema isolation
+    # Schema isolation. `SET search_path` was blocked; the semantically
+    # equivalent `set_config('search_path', …)` and `pg_catalog.set_config(…)`
+    # bypassed it, so block `set_config` unconditionally (a GUC setter has no
+    # legitimate use case via this tool — search_path is the security-relevant
+    # one, but any GUC change is out of scope).
     (re.compile(r"\bSET\s+search_path\b", re.I), "SET search_path is not allowed"),
+    (re.compile(r"\bset_config\b", re.I), "set_config is not allowed"),
     (re.compile(r"\bCREATE\s+SCHEMA\b", re.I), "CREATE SCHEMA is not allowed"),
 ]
 
@@ -65,11 +77,53 @@ def _strip_comments(sql: str) -> str:
     return sqlparse.format(sql, strip_comments=True).strip()
 
 
+def _strip_strings(sql: str) -> str:
+    """Replace every string literal in `sql` with `''`.
+
+    This prevents pattern-based checks from firing on keywords or text that
+    appear inside string values — e.g. `INSERT ... VALUES ('grant access')`
+    must not trip the GRANT block, and `UPDATE t SET memo='reset where needed'`
+    must not satisfy `require_where_on_update`.
+
+    Handles three sqlparse tokenizations:
+
+    - `Token.Literal.String.Single` — `'…'`, `E'…'`, `N'…'`. Strip.
+    - `Token.Literal` (bare) — dollar-quoted bodies `$$…$$` and `$tag$…$tag$`.
+      Strip so `DO $$ GRANT … $$` can't hide the GRANT.
+    - `Token.Literal.String.Symbol` — double-quoted identifiers `"my_table"`.
+      Preserve — these are names, not string data, and stripping them would
+      erase identifier information the caller may legitimately be using.
+    """
+    try:
+        parsed = sqlparse.parse(sql)
+    except Exception:
+        return sql
+    if not parsed:
+        return sql
+
+    parts: list[str] = []
+    for stmt in parsed:
+        for tok in stmt.flatten():
+            ttype = tok.ttype
+            if ttype is None:
+                parts.append(str(tok))
+                continue
+            ttype_str = str(ttype)
+            if ttype_str == "Token.Literal.String.Single" or ttype_str == "Token.Literal":
+                parts.append("''")
+            else:
+                parts.append(str(tok))
+    return "".join(parts)
+
+
 def _count_values_rows(sql: str) -> int | None:
     """Count top-level row tuples in a VALUES clause.
 
     Returns None when no VALUES keyword is found (e.g. INSERT ... SELECT),
     in which case no row-count limit applies.
+
+    Caller is expected to pass string-stripped SQL (see `_strip_strings`) so
+    that `)(` inside a string literal does not falsely inflate the count.
     """
     match = re.search(r"\bVALUES\b", sql, re.I)
     if not match:
@@ -89,7 +143,12 @@ def _count_values_rows(sql: str) -> int | None:
 
 
 def _has_top_level_where(sql: str) -> bool:
-    """Check if a WHERE keyword exists outside of any parenthesized subexpression."""
+    """Check if a WHERE keyword exists outside of any parenthesized subexpression.
+
+    Caller is expected to pass string-stripped SQL (see `_strip_strings`) so
+    that a WHERE appearing inside a string literal does not falsely satisfy
+    `require_where_on_update` / `require_where_on_delete`.
+    """
     depth = 0
     upper = sql.upper()
     i = 0
@@ -107,13 +166,18 @@ def _has_top_level_where(sql: str) -> bool:
     return False
 
 
-def validate_write_query(sql: str, config: GuardrailConfig) -> None:
-    """Validate a write query against all guardrail checks.
+def validate_query(sql: str, config: GuardrailConfig, read_only: bool) -> None:
+    """Validate a SQL query against the guardrail blocklist.
 
-    Raises QueryBlockedError with a human-readable reason if the query is
-    rejected. Does nothing (returns None) when the query passes all checks.
+    Called by both `run_read_only_query` (with `read_only=True`) and
+    `run_write_query` (with `read_only=False`). The dangerous-function
+    blocklist runs in both modes; the write-shape checks (INSERT row limit,
+    require-WHERE) only run when `read_only=False`.
+
+    Raises `QueryBlockedError` with a human-readable reason if the query is
+    rejected. Returns None when the query passes.
     """
-    logger.debug("Validating write query (%d chars)", len(sql))
+    logger.debug("Validating query (%d chars, read_only=%s)", len(sql), read_only)
     stripped = sql.strip()
     if not stripped:
         raise QueryBlockedError("Empty query")
@@ -135,14 +199,26 @@ def validate_write_query(sql: str, config: GuardrailConfig) -> None:
             "Please submit one statement at a time."
         )
 
+    # Strip string literals BEFORE running the pattern-based checks so that
+    # keywords/text inside string values don't cause false positives.
+    for_matching = _strip_strings(cleaned)
+
     for pattern, reason in _BLOCKED_PATTERNS:
-        if pattern.search(cleaned):
-            logger.warning("Write query blocked: %s", reason)
+        if pattern.search(for_matching):
+            logger.warning("Query blocked: %s", reason)
             raise QueryBlockedError(reason)
 
-    upper_cleaned = cleaned.upper().lstrip()
+    if read_only:
+        # Read path: the DB-level BEGIN READ ONLY transaction already blocks
+        # writes at the DB layer; the blocklist above handles read-tool-
+        # specific abuses (pg_read_file, COPY ... TO PROGRAM, dblink, etc.).
+        # No further checks needed.
+        logger.debug("Read-only query passed guardrail checks")
+        return
+
+    upper_cleaned = for_matching.upper().lstrip()
     if upper_cleaned.startswith("INSERT"):
-        row_count = _count_values_rows(cleaned)
+        row_count = _count_values_rows(for_matching)
         if row_count is not None and row_count > config.max_insert_rows:
             raise QueryBlockedError(
                 f"INSERT contains {row_count} rows, which exceeds the "
@@ -151,14 +227,14 @@ def validate_write_query(sql: str, config: GuardrailConfig) -> None:
             )
 
     if config.require_where_on_update and upper_cleaned.startswith("UPDATE"):
-        if not _has_top_level_where(cleaned):
+        if not _has_top_level_where(for_matching):
             raise QueryBlockedError(
                 "UPDATE without a WHERE clause is not allowed "
                 "(YB_MCP_REQUIRE_WHERE_ON_UPDATE is enabled)."
             )
 
     if config.require_where_on_delete and upper_cleaned.startswith("DELETE"):
-        if not _has_top_level_where(cleaned):
+        if not _has_top_level_where(for_matching):
             raise QueryBlockedError(
                 "DELETE without a WHERE clause is not allowed "
                 "(YB_MCP_REQUIRE_WHERE_ON_DELETE is enabled)."

--- a/src/yugabytedb_mcp_server/guardrails.py
+++ b/src/yugabytedb_mcp_server/guardrails.py
@@ -1,8 +1,46 @@
+"""SQL guardrail for the YugabyteDB MCP server.
+
+Every query submitted through `run_read_only_query` or `run_write_query` goes
+through `validate_query()`. The check runs against the sqlparse AST — not
+against raw text — so keywords inside string literals, dollar-quoted bodies,
+and double-quoted identifiers cannot trip or bypass the blocklist.
+
+Blocklists:
+
+- ``_BLOCKED_SINGLE_KEYWORDS`` — a bare keyword whose presence anywhere in
+  the statement is rejected (GRANT, REVOKE, LOAD, COPY, DO).
+- ``_BLOCKED_KEYWORD_PAIRS`` — two-word phrases like ``DROP DATABASE`` /
+  ``ALTER SYSTEM``. Matched only when the two keywords appear adjacent
+  (whitespace / comment tokens skipped), so a DROP DATABASE embedded in a
+  string literal does not match (the literal tokenizes as one String token,
+  not two Keyword tokens).
+- ``_BLOCKED_FUNCTIONS`` — dangerous built-in function names. Detected as a
+  Name token that is immediately followed by ``(``. Handles dotted forms
+  like ``pg_catalog.pg_read_file(…)`` because sqlparse flattens the dotted
+  name into separate Name tokens.
+- ``SET search_path`` — SET keyword followed by an identifier named
+  ``search_path``. Blocks all SET-search-path variants (SET, SET LOCAL,
+  SET SESSION) without blocking legitimate SET commands like
+  ``SET LOCAL statement_timeout``.
+
+Write-only shape checks (skipped when `read_only=True`):
+
+- INSERT row-count limit: counts ``Parenthesis`` children of the top-level
+  ``Values`` group, not raw ``(`` occurrences, so a ``)(`` inside a string
+  literal cannot inflate the count.
+- ``require_where_on_update`` / ``require_where_on_delete``: checks for a
+  ``Where`` group at the top level of the parsed statement, so a WHERE
+  inside a subquery or inside a string literal does not satisfy the check.
+  Uses ``stmt.get_type()`` so ``WITH x AS (…) UPDATE …`` is still
+  recognized as an UPDATE.
+"""
+
 import logging
-import re
 from dataclasses import dataclass
 
 import sqlparse
+from sqlparse import tokens as T
+from sqlparse.sql import Parenthesis, Statement, Values, Where
 
 logger = logging.getLogger("yugabytedb-mcp.guardrails")
 
@@ -19,163 +57,223 @@ class GuardrailConfig:
     require_where_on_delete: bool = False
 
 
-_BLOCKED_PATTERNS: list[tuple[re.Pattern, str]] = [
+# Two-word keyword phrases, matched only when both tokens are Keyword tokens
+# adjacent to each other (whitespace / comments skipped). Because sqlparse
+# tokenizes a keyword-shaped substring inside a string literal as
+# `Token.Literal.String.Single` — not as `Token.Keyword` — no phrase inside
+# a string can match.
+_BLOCKED_KEYWORD_PAIRS: dict[tuple[str, str], str] = {
     # Database / schema destruction
-    (re.compile(r"\bDROP\s+DATABASE\b", re.I), "DROP DATABASE is not allowed"),
-    (re.compile(r"\bDROP\s+SCHEMA\b", re.I), "DROP SCHEMA is not allowed"),
-    (re.compile(r"\bALTER\s+DATABASE\b", re.I), "ALTER DATABASE is not allowed"),
-    (re.compile(r"\bCREATE\s+DATABASE\b", re.I), "CREATE DATABASE is not allowed"),
-
-    # Role / privilege manipulation
-    (re.compile(r"\bGRANT\b", re.I), "GRANT is not allowed"),
-    (re.compile(r"\bREVOKE\b", re.I), "REVOKE is not allowed"),
-    (re.compile(r"\bCREATE\s+ROLE\b", re.I), "CREATE ROLE is not allowed"),
-    (re.compile(r"\bALTER\s+ROLE\b", re.I), "ALTER ROLE is not allowed"),
-    (re.compile(r"\bDROP\s+ROLE\b", re.I), "DROP ROLE is not allowed"),
-    (re.compile(r"\bCREATE\s+USER\b", re.I), "CREATE USER is not allowed"),
-    (re.compile(r"\bALTER\s+USER\b", re.I), "ALTER USER is not allowed"),
-    (re.compile(r"\bDROP\s+USER\b", re.I), "DROP USER is not allowed"),
-
-    # Filesystem access / arbitrary code execution
-    (re.compile(r"\bCOPY\b.+\b(TO|FROM)\b", re.I | re.S), "COPY TO/FROM is not allowed"),
-    (re.compile(r"\bLOAD\s+", re.I), "LOAD is not allowed"),
-    # Match anonymous code blocks: bare `DO $$…$$` AND `DO LANGUAGE plpgsql $$…$$`.
-    # The pre-match _strip_strings pass replaces dollar-quoted bodies with `''`,
-    # so the bare `DO $$…$$` case becomes `DO ''` here — include that shape
-    # explicitly. The LANGUAGE form still parses as `DO LANGUAGE plpgsql ''`.
-    (re.compile(r"\bDO\s+(?:\$|LANGUAGE\b|'')", re.I),
-     "Anonymous code blocks (DO) are not allowed"),
-    (re.compile(r"\bCREATE\s+EXTENSION\b", re.I), "CREATE EXTENSION is not allowed"),
-
-    # Server configuration
-    (re.compile(r"\bALTER\s+SYSTEM\b", re.I), "ALTER SYSTEM is not allowed"),
-    (re.compile(r"\bRESET\s+ALL\b", re.I), "RESET ALL is not allowed"),
-
-    # Dangerous built-in functions
-    (re.compile(r"\bpg_sleep\b", re.I), "pg_sleep is not allowed"),
-    (re.compile(r"\bpg_read_file\b", re.I), "pg_read_file is not allowed"),
-    (re.compile(r"\bpg_read_binary_file\b", re.I), "pg_read_binary_file is not allowed"),
-    (re.compile(r"\bpg_write_file\b", re.I), "pg_write_file is not allowed"),
-    (re.compile(r"\bpg_ls_dir\b", re.I), "pg_ls_dir is not allowed"),
-    (re.compile(r"\blo_import\b", re.I), "lo_import is not allowed"),
-    (re.compile(r"\blo_export\b", re.I), "lo_export is not allowed"),
-    (re.compile(r"\bdblink\b", re.I), "dblink is not allowed"),
-
-    # Schema isolation. `SET search_path` was blocked; the semantically
-    # equivalent `set_config('search_path', …)` and `pg_catalog.set_config(…)`
-    # bypassed it, so block `set_config` unconditionally (a GUC setter has no
-    # legitimate use case via this tool — search_path is the security-relevant
-    # one, but any GUC change is out of scope).
-    (re.compile(r"\bSET\s+search_path\b", re.I), "SET search_path is not allowed"),
-    (re.compile(r"\bset_config\b", re.I), "set_config is not allowed"),
-    (re.compile(r"\bCREATE\s+SCHEMA\b", re.I), "CREATE SCHEMA is not allowed"),
-]
+    ("DROP", "DATABASE"): "DROP DATABASE is not allowed",
+    ("DROP", "SCHEMA"): "DROP SCHEMA is not allowed",
+    ("ALTER", "DATABASE"): "ALTER DATABASE is not allowed",
+    ("CREATE", "DATABASE"): "CREATE DATABASE is not allowed",
+    # Role / user manipulation
+    ("CREATE", "ROLE"): "CREATE ROLE is not allowed",
+    ("ALTER", "ROLE"): "ALTER ROLE is not allowed",
+    ("DROP", "ROLE"): "DROP ROLE is not allowed",
+    ("CREATE", "USER"): "CREATE USER is not allowed",
+    ("ALTER", "USER"): "ALTER USER is not allowed",
+    ("DROP", "USER"): "DROP USER is not allowed",
+    # Server / extension configuration
+    ("CREATE", "EXTENSION"): "CREATE EXTENSION is not allowed",
+    ("ALTER", "SYSTEM"): "ALTER SYSTEM is not allowed",
+    ("RESET", "ALL"): "RESET ALL is not allowed",
+    ("CREATE", "SCHEMA"): "CREATE SCHEMA is not allowed",
+}
 
 
-def _strip_comments(sql: str) -> str:
-    """Remove SQL comments so they cannot hide malicious patterns."""
-    return sqlparse.format(sql, strip_comments=True).strip()
+# Single-keyword bans. A single Keyword token whose normalized value is in
+# this set is rejected on sight.
+_BLOCKED_SINGLE_KEYWORDS: dict[str, str] = {
+    # DCL — role / privilege manipulation
+    "GRANT": "GRANT is not allowed",
+    "REVOKE": "REVOKE is not allowed",
+    # File / library loading
+    "LOAD": "LOAD is not allowed",
+    # Bulk data ops always require TO/FROM/PROGRAM; no legitimate use case
+    # via this tool.
+    "COPY": "COPY TO/FROM is not allowed",
+    # Anonymous code blocks — the code inside is a dollar-quoted body which
+    # sqlparse tokenizes as a single Literal token; there is no way to
+    # inspect its contents, and the block runs arbitrary procedural code.
+    # Block DO in any form (bare `DO $$…$$` and `DO LANGUAGE plpgsql $$…$$`).
+    "DO": "Anonymous code blocks (DO) are not allowed",
+}
 
 
-def _strip_strings(sql: str) -> str:
-    """Replace every string literal in `sql` with `''`.
+# Function names blocked in any context. Matched against Name tokens that are
+# immediately followed by `(`. Handles schema-qualified calls like
+# `pg_catalog.pg_read_file(…)` because sqlparse's `flatten()` emits the
+# unqualified name as its own Name token.
+_BLOCKED_FUNCTIONS: frozenset[str] = frozenset({
+    "pg_sleep",
+    "pg_read_file",
+    "pg_read_binary_file",
+    "pg_write_file",
+    "pg_ls_dir",
+    "pg_ls_logdir",
+    "pg_ls_waldir",
+    "pg_stat_file",
+    "lo_import",
+    "lo_export",
+    "lo_from_bytea",
+    "dblink",
+    "dblink_exec",
+    "dblink_connect",
+    "dblink_send_query",
+    # set_config('search_path', …) is equivalent to `SET search_path`; block
+    # the function form unconditionally (it can change any GUC, none of which
+    # is a legitimate MCP-tool operation).
+    "set_config",
+})
 
-    This prevents pattern-based checks from firing on keywords or text that
-    appear inside string values — e.g. `INSERT ... VALUES ('grant access')`
-    must not trip the GRANT block, and `UPDATE t SET memo='reset where needed'`
-    must not satisfy `require_where_on_update`.
 
-    Handles three sqlparse tokenizations:
+def _is_keyword_token(tok) -> bool:
+    """True if the token's ttype is Token.Keyword or any subtype
+    (Keyword.DDL, Keyword.DML, Keyword.DCL, Keyword.CTE)."""
+    return tok.ttype is not None and tok.ttype in T.Keyword
 
-    - `Token.Literal.String.Single` — `'…'`, `E'…'`, `N'…'`. Strip.
-    - `Token.Literal` (bare) — dollar-quoted bodies `$$…$$` and `$tag$…$tag$`.
-      Strip so `DO $$ GRANT … $$` can't hide the GRANT.
-    - `Token.Literal.String.Symbol` — double-quoted identifiers `"my_table"`.
-      Preserve — these are names, not string data, and stripping them would
-      erase identifier information the caller may legitimately be using.
+
+def _is_name_token(tok) -> bool:
+    """True if the token's ttype is Token.Name (unquoted identifier). Does
+    NOT match Token.Literal.String.Symbol (double-quoted identifiers) —
+    those are preserved as identifier names and never treated as callable
+    functions."""
+    return tok.ttype is not None and tok.ttype in T.Name
+
+
+def _is_punctuation(tok) -> bool:
+    return tok.ttype is not None and tok.ttype in T.Punctuation
+
+
+def _significant_tokens(iterable) -> list:
+    """Return a list of tokens with whitespace and comment tokens stripped."""
+    result = []
+    for t in iterable:
+        if t.is_whitespace:
+            continue
+        if t.ttype is not None and str(t.ttype).startswith("Token.Comment"):
+            continue
+        result.append(t)
+    return result
+
+
+def _check_blocked_ast(stmt: Statement) -> None:
+    """Walk the parsed statement, rejecting blocked keywords, keyword pairs,
+    and function calls. Recurses into subqueries because `Statement.flatten()`
+    yields leaf tokens across the whole tree.
+
+    A keyword-shaped substring inside a string literal is tokenized by
+    sqlparse as a single Token.Literal.String.Single (or Token.Literal for a
+    dollar-quoted body), so no string-literal contents are ever inspected
+    against the blocklists — the class-A false-positive from the audit ticket
+    cannot occur by construction.
     """
-    try:
-        parsed = sqlparse.parse(sql)
-    except Exception:
-        return sql
-    if not parsed:
-        return sql
+    tokens = _significant_tokens(stmt.flatten())
 
-    parts: list[str] = []
-    for stmt in parsed:
-        for tok in stmt.flatten():
-            ttype = tok.ttype
-            if ttype is None:
-                parts.append(str(tok))
-                continue
-            ttype_str = str(ttype)
-            if ttype_str == "Token.Literal.String.Single" or ttype_str == "Token.Literal":
-                parts.append("''")
-            else:
-                parts.append(str(tok))
-    return "".join(parts)
+    for i, tok in enumerate(tokens):
+        if _is_keyword_token(tok):
+            kw = tok.value.upper()
+
+            # Single-keyword bans.
+            if kw in _BLOCKED_SINGLE_KEYWORDS:
+                raise QueryBlockedError(_BLOCKED_SINGLE_KEYWORDS[kw])
+
+            # Two-keyword-pair bans.
+            if i + 1 < len(tokens):
+                nxt = tokens[i + 1]
+                if _is_keyword_token(nxt):
+                    pair_key = (kw, nxt.value.upper())
+                    if pair_key in _BLOCKED_KEYWORD_PAIRS:
+                        raise QueryBlockedError(_BLOCKED_KEYWORD_PAIRS[pair_key])
+
+            # SET search_path (handles SET, SET LOCAL, SET SESSION variants).
+            # `search_path` is not a keyword; sqlparse tokenizes it as Name.
+            # Scan forward from SET until we hit the value side (`TO` or `=`)
+            # or run out of tokens; if any intermediate Name is `search_path`,
+            # block. This still allows `SET LOCAL statement_timeout = '5s'`.
+            if kw == "SET":
+                for j in range(i + 1, len(tokens)):
+                    nxt = tokens[j]
+                    if _is_name_token(nxt) and nxt.value.lower() == "search_path":
+                        raise QueryBlockedError("SET search_path is not allowed")
+                    if _is_keyword_token(nxt) and nxt.value.upper() in ("TO", "="):
+                        break
+                    if _is_punctuation(nxt) and nxt.value == "=":
+                        break
+
+        elif _is_name_token(tok):
+            # Function-call detection: Name followed (immediately, whitespace
+            # already stripped) by `(`. Blocks both plain `pg_read_file(…)`
+            # and dotted `pg_catalog.pg_read_file(…)` — the latter is
+            # flattened by sqlparse into `pg_catalog` Name, `.` Punctuation,
+            # `pg_read_file` Name, `(` Punctuation.
+            name = tok.value.lower()
+            if name in _BLOCKED_FUNCTIONS:
+                if i + 1 < len(tokens):
+                    nxt = tokens[i + 1]
+                    if _is_punctuation(nxt) and nxt.value == "(":
+                        raise QueryBlockedError(f"{name} is not allowed")
 
 
 def _count_values_rows(sql: str) -> int | None:
     """Count top-level row tuples in a VALUES clause.
 
-    Returns None when no VALUES keyword is found (e.g. INSERT ... SELECT),
-    in which case no row-count limit applies.
+    Uses the parsed AST: sqlparse groups a `VALUES (…), (…), (…)` clause as
+    a single `Values` node whose direct children are `Parenthesis` groups
+    (one per row) separated by punctuation commas. A `(`, `)`, or `,`
+    appearing inside a string literal cannot affect the count because those
+    characters are tokenized as part of the enclosing String token, not as
+    separate tokens.
 
-    Caller is expected to pass string-stripped SQL (see `_strip_strings`) so
-    that `)(` inside a string literal does not falsely inflate the count.
+    Returns None when the statement has no top-level Values group
+    (e.g. `INSERT … SELECT`), in which case no row-count limit applies.
     """
-    match = re.search(r"\bVALUES\b", sql, re.I)
-    if not match:
+    parsed = sqlparse.parse(sql)
+    if not parsed:
         return None
-
-    rest = sql[match.end():]
-    depth = 0
-    row_count = 0
-    for ch in rest:
-        if ch == "(":
-            if depth == 0:
-                row_count += 1
-            depth += 1
-        elif ch == ")":
-            depth -= 1
-    return row_count
+    stmt = parsed[0]
+    for tok in stmt.tokens:
+        if isinstance(tok, Values):
+            return sum(1 for child in tok.tokens if isinstance(child, Parenthesis))
+    return None
 
 
 def _has_top_level_where(sql: str) -> bool:
-    """Check if a WHERE keyword exists outside of any parenthesized subexpression.
+    """Return True if a `Where` group exists at the top level of the statement.
 
-    Caller is expected to pass string-stripped SQL (see `_strip_strings`) so
-    that a WHERE appearing inside a string literal does not falsely satisfy
-    `require_where_on_update` / `require_where_on_delete`.
+    sqlparse groups the WHERE clause of the outermost UPDATE/DELETE/SELECT as
+    a top-level `Where` node. A WHERE inside a nested subquery lives inside a
+    `Parenthesis` group and is not visible at the top level. A WHERE inside a
+    string literal is not a token at all (the whole literal is one String
+    token). So this correctly distinguishes real top-level WHEREs from
+    lookalikes inside subqueries or strings.
     """
-    depth = 0
-    upper = sql.upper()
-    i = 0
-    while i < len(upper):
-        ch = upper[i]
-        if ch == "(":
-            depth += 1
-        elif ch == ")":
-            depth = max(depth - 1, 0)
-        elif depth == 0 and upper[i:i+5] == "WHERE" and (i == 0 or not upper[i-1].isalnum() and upper[i-1] != "_"):
-            end = i + 5
-            if end >= len(upper) or (not upper[end].isalnum() and upper[end] != "_"):
-                return True
-        i += 1
-    return False
+    parsed = sqlparse.parse(sql)
+    if not parsed:
+        return False
+    stmt = parsed[0]
+    return any(isinstance(t, Where) for t in stmt.tokens)
+
+
+def _strip_comments(sql: str) -> str:
+    """Remove SQL comments so they cannot hide malicious patterns from
+    multi-statement / psql-meta detection. The AST walker itself already
+    ignores comment tokens, but comments-inside-comments and other edge
+    cases are simplest to handle by stripping up front."""
+    return sqlparse.format(sql, strip_comments=True).strip()
 
 
 def validate_query(sql: str, config: GuardrailConfig, read_only: bool) -> None:
-    """Validate a SQL query against the guardrail blocklist.
+    """Validate a SQL query.
 
-    Called by both `run_read_only_query` (with `read_only=True`) and
-    `run_write_query` (with `read_only=False`). The dangerous-function
-    blocklist runs in both modes; the write-shape checks (INSERT row limit,
-    require-WHERE) only run when `read_only=False`.
+    Both `run_read_only_query` (with `read_only=True`) and `run_write_query`
+    (with `read_only=False`) call this function. The dangerous-keyword and
+    dangerous-function blocklists run in both modes; the write-shape checks
+    (INSERT row limit, require-WHERE) only run when `read_only=False`.
 
-    Raises `QueryBlockedError` with a human-readable reason if the query is
-    rejected. Returns None when the query passes.
+    Raises `QueryBlockedError` with a human-readable reason on rejection.
     """
     logger.debug("Validating query (%d chars, read_only=%s)", len(sql), read_only)
     stripped = sql.strip()
@@ -192,6 +290,7 @@ def validate_query(sql: str, config: GuardrailConfig, read_only: bool) -> None:
     if not cleaned:
         raise QueryBlockedError("Query is empty after removing comments")
 
+    # Multi-statement rejection via sqlparse.split (respects strings correctly).
     statements = [s for s in sqlparse.split(cleaned) if s.strip()]
     if len(statements) > 1:
         raise QueryBlockedError(
@@ -199,26 +298,29 @@ def validate_query(sql: str, config: GuardrailConfig, read_only: bool) -> None:
             "Please submit one statement at a time."
         )
 
-    # Strip string literals BEFORE running the pattern-based checks so that
-    # keywords/text inside string values don't cause false positives.
-    for_matching = _strip_strings(cleaned)
+    parsed = sqlparse.parse(cleaned)
+    if not parsed or not parsed[0].tokens:
+        raise QueryBlockedError("Query is empty after parsing")
+    stmt = parsed[0]
 
-    for pattern, reason in _BLOCKED_PATTERNS:
-        if pattern.search(for_matching):
-            logger.warning("Query blocked: %s", reason)
-            raise QueryBlockedError(reason)
+    # AST-based blocklist. Runs in both read and write modes.
+    _check_blocked_ast(stmt)
 
     if read_only:
-        # Read path: the DB-level BEGIN READ ONLY transaction already blocks
-        # writes at the DB layer; the blocklist above handles read-tool-
-        # specific abuses (pg_read_file, COPY ... TO PROGRAM, dblink, etc.).
-        # No further checks needed.
+        # Read path: the DB-level BEGIN READ ONLY transaction blocks writes
+        # at the DB layer; the AST blocklist above blocks the read-tool-
+        # specific abuses (pg_read_file, COPY, dblink, pg_sleep, DO, GRANT,
+        # …). No further checks needed.
         logger.debug("Read-only query passed guardrail checks")
         return
 
-    upper_cleaned = for_matching.upper().lstrip()
-    if upper_cleaned.startswith("INSERT"):
-        row_count = _count_values_rows(for_matching)
+    # Write path: additional shape checks. `stmt.get_type()` recognizes
+    # `WITH … UPDATE` as UPDATE, so the require-WHERE check still fires on
+    # a CTE-prefixed UPDATE/DELETE.
+    stmt_type = (stmt.get_type() or "").upper()
+
+    if stmt_type == "INSERT":
+        row_count = _count_values_rows(cleaned)
         if row_count is not None and row_count > config.max_insert_rows:
             raise QueryBlockedError(
                 f"INSERT contains {row_count} rows, which exceeds the "
@@ -226,15 +328,15 @@ def validate_query(sql: str, config: GuardrailConfig, read_only: bool) -> None:
                 f"Please split into smaller batches."
             )
 
-    if config.require_where_on_update and upper_cleaned.startswith("UPDATE"):
-        if not _has_top_level_where(for_matching):
+    if config.require_where_on_update and stmt_type == "UPDATE":
+        if not _has_top_level_where(cleaned):
             raise QueryBlockedError(
                 "UPDATE without a WHERE clause is not allowed "
                 "(YB_MCP_REQUIRE_WHERE_ON_UPDATE is enabled)."
             )
 
-    if config.require_where_on_delete and upper_cleaned.startswith("DELETE"):
-        if not _has_top_level_where(for_matching):
+    if config.require_where_on_delete and stmt_type == "DELETE":
+        if not _has_top_level_where(cleaned):
             raise QueryBlockedError(
                 "DELETE without a WHERE clause is not allowed "
                 "(YB_MCP_REQUIRE_WHERE_ON_DELETE is enabled)."

--- a/src/yugabytedb_mcp_server/server.py
+++ b/src/yugabytedb_mcp_server/server.py
@@ -268,12 +268,6 @@ class YugabyteDBMCPServer:
 
     def _register_tools(self):
         _ro = {"readOnlyHint": True, "destructiveHint": False}
-        # run_read_only_query executes arbitrary SQL, so despite the name it
-        # CAN modify the environment (COPY, dblink, side-effecting functions
-        # — the guardrail in tools.py blocks the worst offenders, but the tool
-        # is not annotation-level read-only). Mark it destructive so MCP
-        # clients present a confirmation prompt.
-        _read_dest = {"readOnlyHint": False, "destructiveHint": True, "idempotentHint": True}
         _dest = {"readOnlyHint": False, "destructiveHint": True, "idempotentHint": False}
 
         self.mcp.tool(
@@ -282,7 +276,7 @@ class YugabyteDBMCPServer:
         )
         self.mcp.tool(
             run_read_only_query,
-            annotations={**_read_dest, "title": "Run a read-only SQL query"},
+            annotations={**_ro, "title": "Run a read-only SQL query"},
         )
         if CONFIG.enable_write_query:
             self.mcp.tool(

--- a/src/yugabytedb_mcp_server/server.py
+++ b/src/yugabytedb_mcp_server/server.py
@@ -268,6 +268,12 @@ class YugabyteDBMCPServer:
 
     def _register_tools(self):
         _ro = {"readOnlyHint": True, "destructiveHint": False}
+        # run_read_only_query executes arbitrary SQL, so despite the name it
+        # CAN modify the environment (COPY, dblink, side-effecting functions
+        # — the guardrail in tools.py blocks the worst offenders, but the tool
+        # is not annotation-level read-only). Mark it destructive so MCP
+        # clients present a confirmation prompt.
+        _read_dest = {"readOnlyHint": False, "destructiveHint": True, "idempotentHint": True}
         _dest = {"readOnlyHint": False, "destructiveHint": True, "idempotentHint": False}
 
         self.mcp.tool(
@@ -276,7 +282,7 @@ class YugabyteDBMCPServer:
         )
         self.mcp.tool(
             run_read_only_query,
-            annotations={**_ro, "title": "Run a read-only SQL query"},
+            annotations={**_read_dest, "title": "Run a read-only SQL query"},
         )
         if CONFIG.enable_write_query:
             self.mcp.tool(

--- a/src/yugabytedb_mcp_server/tools.py
+++ b/src/yugabytedb_mcp_server/tools.py
@@ -12,6 +12,7 @@ to the authenticated user's identity.
 
 import json
 import logging
+import math
 from contextlib import contextmanager
 from typing import Any, Dict, List
 
@@ -19,9 +20,39 @@ from fastmcp import Context
 from fastmcp.server.dependencies import get_access_token
 from psycopg.sql import SQL, Identifier
 
-from .guardrails import GuardrailConfig, QueryBlockedError, validate_write_query
+from .guardrails import GuardrailConfig, QueryBlockedError, validate_query
 
 logger = logging.getLogger("yugabytedb-mcp.tools")
+
+
+def _sanitize_for_json(value: Any) -> Any:
+    """Convert values into JSON-safe forms before serialization.
+
+    Handles two classes of bugs in the previous `json.dumps(..., default=str)`
+    path:
+
+    - Float `NaN`, `Infinity`, `-Infinity` — Python's `json.dumps` emits them
+      as bare tokens, which are invalid JSON per RFC 8259 (JS `JSON.parse`
+      rejects them). Map non-finite floats to `None`.
+    - `bytes` / `memoryview` — the previous `default=str` produced the lossy
+      Python bytes-repr (`"b'\\xde\\xad\\xbe\\xef'"`). Encode as
+      `{"$hex": "deadbeef"}` for a lossless, well-defined round-trip.
+
+    Recursive so nested `list` / `dict` / array-column values are covered.
+    Any type not matched here falls through to `json.dumps`'s `default=str`
+    for datetime / Decimal / UUID / IPv4Address etc. (existing coverage).
+    """
+    if isinstance(value, float) and not math.isfinite(value):
+        return None
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return {"$hex": bytes(value).hex()}
+    if isinstance(value, list):
+        return [_sanitize_for_json(v) for v in value]
+    if isinstance(value, tuple):
+        return [_sanitize_for_json(v) for v in value]
+    if isinstance(value, dict):
+        return {k: _sanitize_for_json(v) for k, v in value.items()}
+    return value
 
 
 def _execute(cur, query, params: tuple | None = None) -> None:
@@ -191,8 +222,10 @@ def run_read_only_query(ctx: Context, query: str) -> str:
     Run a read-only SQL query under BEGIN READ ONLY and return the rows as
     JSON.
 
-    Any data-mutating statement is rejected by the database itself because
-    of the read-only transaction.
+    The query is validated against the same dangerous-function blocklist
+    used by run_write_query before it reaches the database: side-effecting
+    built-ins (COPY … TO PROGRAM, pg_read_file, dblink, pg_sleep, …) are
+    rejected even though BEGIN READ ONLY would let some of them run.
 
     Args:
         ctx: MCP context (injected automatically).
@@ -200,7 +233,15 @@ def run_read_only_query(ctx: Context, query: str) -> str:
     """
     logger.info("run_read_only_query called")
     logger.debug("Query: %s", query)
-    pool = ctx.request_context.lifespan_context["pool"]
+    lifespan = ctx.request_context.lifespan_context
+    pool = lifespan["pool"]
+    guardrail_config: GuardrailConfig = lifespan["guardrail_config"]
+
+    try:
+        validate_query(query, guardrail_config, read_only=True)
+    except QueryBlockedError as e:
+        logger.warning("Read query blocked by guardrail: %s", e)
+        return json.dumps({"error": str(e), "blocked_by_guardrail": True})
 
     try:
         role = _get_db_role(ctx)
@@ -221,7 +262,8 @@ def run_read_only_query(ctx: Context, query: str) -> str:
                     "run_read_only_query returned %d rows × %d columns",
                     len(rows), len(column_names),
                 )
-                return json.dumps(result, indent=2, default=str)
+                sanitized = _sanitize_for_json(result)
+                return json.dumps(sanitized, indent=2, default=str, allow_nan=False)
             except Exception as e:
                 logger.error("Error executing read-only query: %s", e, exc_info=True)
                 return f"Error executing query: {e}"
@@ -256,7 +298,7 @@ def run_write_query(ctx: Context, query: str) -> str:
     guardrail_config: GuardrailConfig = lifespan["guardrail_config"]
 
     try:
-        validate_write_query(query, guardrail_config)
+        validate_query(query, guardrail_config, read_only=False)
     except QueryBlockedError as e:
         logger.warning("Query blocked by guardrail: %s", e)
         return json.dumps({"error": str(e), "blocked_by_guardrail": True})

--- a/src/yugabytedb_mcp_server/tools.py
+++ b/src/yugabytedb_mcp_server/tools.py
@@ -219,8 +219,14 @@ def summarize_database(ctx: Context, schema: str = "public") -> List[Dict[str, A
 
 def run_read_only_query(ctx: Context, query: str) -> str:
     """
-    Run a read-only SQL query under BEGIN READ ONLY and return the rows as
-    JSON.
+    Run a read-only SQL query under BEGIN READ ONLY and return the result
+    as JSON: `{"columns": [<name>, ...], "rows": [[<val>, ...], ...]}`.
+
+    Columns and rows are returned as parallel arrays rather than a
+    list-of-dicts so duplicate output-column names (e.g. `SELECT 1 AS id,
+    2 AS id` or `SELECT *` over a join) are preserved losslessly. In the
+    previous list-of-dicts shape, dict-key collision silently dropped all
+    but the last duplicate.
 
     The query is validated against the same dangerous-function blocklist
     used by run_write_query before it reaches the database: side-effecting
@@ -257,7 +263,10 @@ def run_read_only_query(ctx: Context, query: str) -> str:
                 _execute(cur, query)
                 rows = cur.fetchall()
                 column_names = [desc[0] for desc in cur.description]
-                result = [dict(zip(column_names, row)) for row in rows]
+                result = {
+                    "columns": column_names,
+                    "rows": [list(row) for row in rows],
+                }
                 logger.info(
                     "run_read_only_query returned %d rows × %d columns",
                     len(rows), len(column_names),

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -7,7 +7,7 @@ import pytest
 from yugabytedb_mcp_server.guardrails import (
     GuardrailConfig,
     QueryBlockedError,
-    validate_write_query,
+    validate_query,
     _count_values_rows,
     _has_top_level_where,
     _strip_comments,
@@ -51,7 +51,7 @@ def strict_cfg():
     "INSERT INTO t SELECT * FROM s",      # INSERT ... SELECT has no row-count enforcement
 ])
 def test_allows(sql, cfg):
-    validate_write_query(sql, cfg)  # raises if blocked
+    validate_query(sql, cfg, read_only=False)  # raises if blocked
 
 
 # ---------------------------------------------------------------------------
@@ -67,7 +67,7 @@ def test_allows(sql, cfg):
 ])
 def test_blocks_db_destruction(sql, fragment, cfg):
     with pytest.raises(QueryBlockedError) as exc:
-        validate_write_query(sql, cfg)
+        validate_query(sql, cfg, read_only=False)
     assert fragment in str(exc.value)
 
 
@@ -87,7 +87,7 @@ def test_blocks_db_destruction(sql, fragment, cfg):
 ])
 def test_blocks_role_manipulation(sql, cfg):
     with pytest.raises(QueryBlockedError):
-        validate_write_query(sql, cfg)
+        validate_query(sql, cfg, read_only=False)
 
 
 # ---------------------------------------------------------------------------
@@ -104,7 +104,7 @@ def test_blocks_role_manipulation(sql, cfg):
 ])
 def test_blocks_filesystem_and_code(sql, cfg):
     with pytest.raises(QueryBlockedError):
-        validate_write_query(sql, cfg)
+        validate_query(sql, cfg, read_only=False)
 
 
 # ---------------------------------------------------------------------------
@@ -117,7 +117,7 @@ def test_blocks_filesystem_and_code(sql, cfg):
 ])
 def test_blocks_server_config(sql, cfg):
     with pytest.raises(QueryBlockedError):
-        validate_write_query(sql, cfg)
+        validate_query(sql, cfg, read_only=False)
 
 
 # ---------------------------------------------------------------------------
@@ -134,7 +134,7 @@ def test_blocks_server_config(sql, cfg):
 ])
 def test_blocks_dangerous_functions(sql, cfg):
     with pytest.raises(QueryBlockedError):
-        validate_write_query(sql, cfg)
+        validate_query(sql, cfg, read_only=False)
 
 
 # ---------------------------------------------------------------------------
@@ -147,7 +147,7 @@ def test_blocks_dangerous_functions(sql, cfg):
 ])
 def test_blocks_schema_isolation(sql, cfg):
     with pytest.raises(QueryBlockedError):
-        validate_write_query(sql, cfg)
+        validate_query(sql, cfg, read_only=False)
 
 
 # ---------------------------------------------------------------------------
@@ -161,7 +161,7 @@ def test_blocks_schema_isolation(sql, cfg):
 ])
 def test_blocks_multistatement(sql, cfg):
     with pytest.raises(QueryBlockedError) as exc:
-        validate_write_query(sql, cfg)
+        validate_query(sql, cfg, read_only=False)
     assert "Multi-statement" in str(exc.value)
 
 
@@ -177,7 +177,7 @@ def test_blocks_multistatement(sql, cfg):
 ])
 def test_strips_comments_before_check(sql, cfg):
     with pytest.raises(QueryBlockedError):
-        validate_write_query(sql, cfg)
+        validate_query(sql, cfg, read_only=False)
 
 
 # ---------------------------------------------------------------------------
@@ -191,7 +191,7 @@ def test_strips_comments_before_check(sql, cfg):
 ])
 def test_blocks_psql_meta(sql, cfg):
     with pytest.raises(QueryBlockedError) as exc:
-        validate_write_query(sql, cfg)
+        validate_query(sql, cfg, read_only=False)
     assert "meta-command" in str(exc.value)
 
 
@@ -207,7 +207,7 @@ def test_blocks_psql_meta(sql, cfg):
 ])
 def test_blocks_empty(sql, cfg):
     with pytest.raises(QueryBlockedError):
-        validate_write_query(sql, cfg)
+        validate_query(sql, cfg, read_only=False)
 
 
 # ---------------------------------------------------------------------------
@@ -216,19 +216,19 @@ def test_blocks_empty(sql, cfg):
 
 def test_bulk_insert_under_limit(cfg):
     rows = ", ".join(["(1)"] * cfg.max_insert_rows)
-    validate_write_query(f"INSERT INTO t VALUES {rows}", cfg)
+    validate_query(f"INSERT INTO t VALUES {rows}", cfg, read_only=False)
 
 
 def test_bulk_insert_over_limit(cfg):
     rows = ", ".join(["(1)"] * (cfg.max_insert_rows + 1))
     with pytest.raises(QueryBlockedError) as exc:
-        validate_write_query(f"INSERT INTO t VALUES {rows}", cfg)
+        validate_query(f"INSERT INTO t VALUES {rows}", cfg, read_only=False)
     assert "exceeds the maximum" in str(exc.value)
 
 
 def test_bulk_insert_select_no_limit(cfg):
     # INSERT ... SELECT has no VALUES, so row-count limit does not apply
-    validate_write_query("INSERT INTO t SELECT * FROM huge_table", cfg)
+    validate_query("INSERT INTO t SELECT * FROM huge_table", cfg, read_only=False)
 
 
 # ---------------------------------------------------------------------------
@@ -237,22 +237,22 @@ def test_bulk_insert_select_no_limit(cfg):
 
 def test_update_without_where_blocked_when_strict(strict_cfg):
     with pytest.raises(QueryBlockedError) as exc:
-        validate_write_query("UPDATE t SET c = 1", strict_cfg)
+        validate_query("UPDATE t SET c = 1", strict_cfg, read_only=False)
     assert "UPDATE without a WHERE" in str(exc.value)
 
 
 def test_update_with_where_allowed_when_strict(strict_cfg):
-    validate_write_query("UPDATE t SET c = 1 WHERE id = 1", strict_cfg)
+    validate_query("UPDATE t SET c = 1 WHERE id = 1", strict_cfg, read_only=False)
 
 
 def test_delete_without_where_blocked_when_strict(strict_cfg):
     with pytest.raises(QueryBlockedError) as exc:
-        validate_write_query("DELETE FROM t", strict_cfg)
+        validate_query("DELETE FROM t", strict_cfg, read_only=False)
     assert "DELETE without a WHERE" in str(exc.value)
 
 
 def test_delete_with_where_allowed_when_strict(strict_cfg):
-    validate_write_query("DELETE FROM t WHERE id = 1", strict_cfg)
+    validate_query("DELETE FROM t WHERE id = 1", strict_cfg, read_only=False)
 
 
 # ---------------------------------------------------------------------------
@@ -287,3 +287,131 @@ def test_has_top_level_where_in_subquery_doesnt_count():
 def test_strip_comments_removes_both_styles():
     assert "DROP" in _strip_comments("/* hide */ DROP TABLE t -- end")
     assert "hide" not in _strip_comments("/* hide */ DROP TABLE t")
+
+
+# ---------------------------------------------------------------------------
+# DB-22131: keyword-in-string-literal must not trip the guardrail
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("sql", [
+    # (A) legitimate writes whose data happens to contain a blocked keyword
+    "INSERT INTO audit(action) VALUES ('grant access to vault')",
+    "UPDATE tickets SET note = 'please revoke the old token'",
+    "INSERT INTO runbook(step) VALUES ('never run DROP DATABASE x')",
+    "INSERT INTO logs(msg) VALUES ('user called pg_read_file to debug')",
+    "INSERT INTO logs(msg) VALUES ('COPY the file TO the vault')",
+    "INSERT INTO logs(msg) VALUES ('DO NOT touch this')",
+    "UPDATE t SET note = 'ALTER SYSTEM was rejected' WHERE id = 1",
+])
+def test_string_literal_keywords_do_not_false_positive(sql, cfg):
+    validate_query(sql, cfg, read_only=False)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# DB-22131: advertised protections must not be bypassable by equivalent syntax
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("sql", [
+    # set_config('search_path', …) is equivalent to SET search_path — block both
+    "SELECT set_config('search_path', 'evil', false)",
+    "SELECT set_config( 'search_path' , 'evil' , false )",
+    'SELECT set_config("search_path", \'evil\', false)',
+])
+def test_blocks_set_config_search_path_bypass(sql, cfg):
+    with pytest.raises(QueryBlockedError):
+        validate_query(sql, cfg, read_only=False)
+
+
+@pytest.mark.parametrize("sql", [
+    "DO $$ BEGIN PERFORM 1; END $$",
+    "DO LANGUAGE plpgsql $$ BEGIN PERFORM 1; END $$",
+    "do language plpgsql $$ begin perform 1; end $$",
+])
+def test_blocks_do_block_regardless_of_language_clause(sql, cfg):
+    with pytest.raises(QueryBlockedError):
+        validate_query(sql, cfg, read_only=False)
+
+
+def test_where_in_string_literal_does_not_satisfy_strict_where(strict_cfg):
+    # DB-22131 class C: 'reset where needed' inside a string must not
+    # count as a real WHERE clause.
+    with pytest.raises(QueryBlockedError) as exc:
+        validate_query(
+            "UPDATE accounts SET memo='reset where needed'",
+            strict_cfg, read_only=False,
+        )
+    assert "WHERE" in str(exc.value)
+
+
+def test_parens_in_string_literal_do_not_inflate_insert_row_count(cfg):
+    # DB-22131 class C: ')(' inside a string was previously counted as a
+    # new row tuple. Verify a 1-row INSERT with such a value passes.
+    validate_query(
+        "INSERT INTO t (msg) VALUES ('has )( parens')",
+        cfg, read_only=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# DB-22129: read-only path still blocks side-effecting SQL
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("sql", [
+    "COPY (SELECT 1) TO PROGRAM 'id > /tmp/poc'",
+    "SELECT pg_read_file('/etc/hostname')",
+    "SELECT pg_read_binary_file('/etc/hostname')",
+    "SELECT * FROM dblink('host=evil', 'SELECT secret')",
+    "SELECT pg_sleep(60)",
+    "SELECT lo_import('/etc/passwd')",
+    "SELECT set_config('search_path', 'evil', false)",
+])
+def test_read_only_blocks_dangerous_reads(sql, cfg):
+    with pytest.raises(QueryBlockedError):
+        validate_query(sql, cfg, read_only=True)
+
+
+@pytest.mark.parametrize("sql", [
+    "SELECT 1",
+    "SELECT * FROM t WHERE id = 1",
+    "SELECT count(*) FROM information_schema.tables",
+    "WITH x AS (SELECT 1) SELECT * FROM x",
+])
+def test_read_only_allows_normal_selects(sql, cfg):
+    validate_query(sql, cfg, read_only=True)  # must not raise
+
+
+def test_read_only_skips_insert_row_count(cfg):
+    # A SELECT is never an INSERT, so the row-count check should no-op even
+    # if the query mentions VALUES.
+    validate_query("SELECT * FROM (VALUES (1), (2), (3)) AS v(x)", cfg, read_only=True)
+
+
+def test_read_only_skips_require_where(strict_cfg):
+    # SELECTs don't start with UPDATE/DELETE, so the WHERE-required check
+    # should not fire on the read path.
+    validate_query("SELECT * FROM t", strict_cfg, read_only=True)
+
+
+# ---------------------------------------------------------------------------
+# _strip_strings helper
+# ---------------------------------------------------------------------------
+
+def test_strip_strings_replaces_single_quoted():
+    from yugabytedb_mcp_server.guardrails import _strip_strings
+    assert _strip_strings("SELECT 'GRANT'") == "SELECT ''"
+
+
+def test_strip_strings_replaces_dollar_quoted():
+    from yugabytedb_mcp_server.guardrails import _strip_strings
+    # Dollar-quoted strings should also be replaced so DO $$ ... GRANT ... $$
+    # can't hide GRANT inside a code block.
+    stripped = _strip_strings("DO $$ GRANT ALL ON t TO evil $$")
+    assert "GRANT" not in stripped
+
+
+def test_strip_strings_preserves_identifiers():
+    from yugabytedb_mcp_server.guardrails import _strip_strings
+    # Double-quoted identifiers must NOT be treated as strings — otherwise
+    # `UPDATE "GRANT"` would look like `UPDATE ''` and no longer be a valid
+    # keyword to match. sqlparse tokenizes them as Token.Name, not String.
+    assert '"my_table"' in _strip_strings('SELECT * FROM "my_table"')

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -521,3 +521,66 @@ def test_bare_commit_alone_not_multi_statement(cfg):
     validate_query("COMMIT", cfg, read_only=True)
     validate_query("END", cfg, read_only=True)
     validate_query("ROLLBACK", cfg, read_only=True)
+
+
+# ---------------------------------------------------------------------------
+# DB-22129: privileged catalog tables (credential / statistics disclosure)
+# ---------------------------------------------------------------------------
+# `SELECT rolname, rolpassword FROM pg_authid` was called out in the DB-22129
+# repro list. The function blocklist doesn't catch it (pg_authid is a table,
+# not a function), so we cover it via a table-name blocklist walked in the
+# same AST pass. Applies to both read and write paths.
+
+
+@pytest.mark.parametrize("sql", [
+    "SELECT rolname, rolpassword FROM pg_authid",
+    "SELECT * FROM pg_authid",
+    "SELECT rolname FROM pg_catalog.pg_authid",
+    "SELECT * FROM pg_shadow",
+    "SELECT * FROM pg_catalog.pg_shadow",
+    "SELECT * FROM pg_user_mappings",
+    "SELECT * FROM pg_statistic",
+    "SELECT * FROM pg_catalog.pg_statistic",
+    # JOIN target
+    "SELECT a.oid FROM pg_class a JOIN pg_authid b ON a.relowner = b.oid",
+    # Subquery reference
+    "SELECT (SELECT rolpassword FROM pg_authid LIMIT 1) AS x",
+    # CTE reference
+    "WITH c AS (SELECT * FROM pg_authid) SELECT * FROM c",
+])
+def test_blocks_privileged_catalog_reads_read_path(sql, cfg):
+    """DB-22129: reads of credential/statistics catalogs are guardrail-blocked
+    on the read path regardless of whether Postgres RBAC would also reject."""
+    with pytest.raises(QueryBlockedError, match="not allowed"):
+        validate_query(sql, cfg, read_only=True)
+
+
+@pytest.mark.parametrize("sql", [
+    "UPDATE pg_authid SET rolpassword = 'x'",
+    "DELETE FROM pg_shadow",
+    "INSERT INTO pg_user_mappings VALUES (1, 2, ARRAY['x'])",
+])
+def test_blocks_privileged_catalog_writes(sql, cfg):
+    """DB-22129: same tables are also blocked on the write path — an operator
+    running the server as a role with catalog-modification privileges must not
+    be able to mutate them via run_write_query."""
+    with pytest.raises(QueryBlockedError, match="not allowed"):
+        validate_query(sql, cfg, read_only=False)
+
+
+@pytest.mark.parametrize("sql", [
+    # String literal — sqlparse tokenizes as String.Single, not Name.
+    "SELECT 'pg_authid' AS x",
+    # Double-quoted identifier — tokenized as Symbol, not Name.
+    'SELECT 1 AS "pg_authid"',
+    # Different, unprivileged tables must not be flagged.
+    "SELECT * FROM pg_roles",
+    "SELECT * FROM pg_stat_activity",
+    "SELECT * FROM pg_catalog.pg_class",
+    "SELECT * FROM information_schema.tables",
+])
+def test_privileged_catalog_blocklist_no_false_positives(sql, cfg):
+    """String literals, double-quoted identifiers, and unprivileged catalogs
+    that only share a prefix with blocked names must pass through."""
+    # No raise expected.
+    validate_query(sql, cfg, read_only=True)

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -393,25 +393,131 @@ def test_read_only_skips_require_where(strict_cfg):
 
 
 # ---------------------------------------------------------------------------
-# _strip_strings helper
+# AST-based detection edge cases — new behaviors from the parser rewrite
 # ---------------------------------------------------------------------------
 
-def test_strip_strings_replaces_single_quoted():
-    from yugabytedb_mcp_server.guardrails import _strip_strings
-    assert _strip_strings("SELECT 'GRANT'") == "SELECT ''"
+def test_blocks_schema_qualified_dangerous_function(cfg):
+    # pg_catalog.pg_read_file(…) — sqlparse flattens the dotted name into
+    # separate Name tokens, so the unqualified `pg_read_file` still matches
+    # the function blocklist.
+    with pytest.raises(QueryBlockedError) as exc:
+        validate_query("SELECT pg_catalog.pg_read_file('/etc')", cfg, read_only=True)
+    assert "pg_read_file" in str(exc.value)
 
 
-def test_strip_strings_replaces_dollar_quoted():
-    from yugabytedb_mcp_server.guardrails import _strip_strings
-    # Dollar-quoted strings should also be replaced so DO $$ ... GRANT ... $$
-    # can't hide GRANT inside a code block.
-    stripped = _strip_strings("DO $$ GRANT ALL ON t TO evil $$")
-    assert "GRANT" not in stripped
+def test_allows_pg_read_file_as_string_literal(cfg):
+    # The literal 'pg_read_file' inside a WHERE clause must not match the
+    # function blocklist — it's not a Name token, it's inside a String.Single.
+    validate_query(
+        "SELECT * FROM my_table WHERE name = 'pg_read_file'",
+        cfg, read_only=True,
+    )
 
 
-def test_strip_strings_preserves_identifiers():
-    from yugabytedb_mcp_server.guardrails import _strip_strings
-    # Double-quoted identifiers must NOT be treated as strings — otherwise
-    # `UPDATE "GRANT"` would look like `UPDATE ''` and no longer be a valid
-    # keyword to match. sqlparse tokenizes them as Token.Name, not String.
-    assert '"my_table"' in _strip_strings('SELECT * FROM "my_table"')
+def test_allows_pg_read_file_as_quoted_identifier(cfg):
+    # A double-quoted identifier "pg_read_file" is tokenized as
+    # String.Symbol (a Name, not a String literal). It's an identifier ref,
+    # not a call — no following `(` — so it must not be blocked.
+    validate_query(
+        'SELECT "pg_read_file" FROM my_table',
+        cfg, read_only=True,
+    )
+
+
+def test_allows_set_local_statement_timeout(cfg):
+    # `SET LOCAL statement_timeout = '5s'` is a legitimate performance knob
+    # that PR #5 will use internally — must not be blocked by the
+    # SET-search_path rule.
+    validate_query(
+        "SET LOCAL statement_timeout = '5s'",
+        cfg, read_only=False,
+    )
+
+
+def test_blocks_set_search_path_all_variants(cfg):
+    for sql in [
+        "SET search_path TO evil",
+        "SET search_path = evil",
+        "SET LOCAL search_path TO evil",
+        "SET SESSION search_path TO evil",
+    ]:
+        with pytest.raises(QueryBlockedError) as exc:
+            validate_query(sql, cfg, read_only=False)
+        assert "search_path" in str(exc.value)
+
+
+def test_blocks_grant_inside_dollar_quoted_do_block(cfg):
+    # DO $$ … $$ is blocked outright (any DO block is rejected), so even
+    # if it contained an attempted GRANT the outer DO block catches it first.
+    with pytest.raises(QueryBlockedError) as exc:
+        validate_query("DO $$ GRANT ALL ON t TO evil $$", cfg, read_only=False)
+    assert "DO" in str(exc.value) or "Anonymous" in str(exc.value)
+
+
+def test_top_level_where_detected_after_cte(strict_cfg):
+    # WITH x AS (…) UPDATE t SET c = 1 — stmt.get_type() returns 'UPDATE'
+    # and the top-level Where check should fire. Without a top-level WHERE,
+    # this should be rejected under strict config.
+    with pytest.raises(QueryBlockedError):
+        validate_query(
+            "WITH x AS (SELECT 1) UPDATE t SET c = 1",
+            strict_cfg, read_only=False,
+        )
+    # But with a real top-level WHERE, it should pass.
+    validate_query(
+        "WITH x AS (SELECT 1) UPDATE t SET c = 1 WHERE id = 1",
+        strict_cfg, read_only=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# DB-22172: read-tool multi-statement escape via COMMIT/END prefix
+# ---------------------------------------------------------------------------
+# The read tool wraps queries in `BEGIN READ ONLY ... ROLLBACK`, but a caller
+# whose input starts with COMMIT/END closes the read-only transaction before
+# subsequent statements run — those then auto-commit outside the wrapper. The
+# multi-statement rejection in validate_query() catches this on both read and
+# write paths.
+
+@pytest.mark.parametrize("sql", [
+    "COMMIT; INSERT INTO t VALUES (1)",
+    "END; DROP TABLE t",
+    "COMMIT; UPDATE t SET c = 1",
+    "END; CREATE TABLE t (id int)",
+    "COMMIT; DELETE FROM t",
+    "COMMIT ; INSERT INTO t VALUES (1)",       # extra whitespace before ;
+    "commit; insert into t values (1)",         # lowercase
+    "COMMIT;\nINSERT INTO t VALUES (1)",       # newline separator
+    "COMMIT; SELECT 1",                          # even a second SELECT is blocked
+])
+def test_multi_statement_escape_blocked_read_only(sql, cfg):
+    """DB-22172: read tool must reject multi-statement input so a COMMIT/END
+    prefix cannot end the BEGIN READ ONLY transaction and let downstream
+    statements auto-commit outside the read-only wrapper."""
+    with pytest.raises(QueryBlockedError) as exc:
+        validate_query(sql, cfg, read_only=True)
+    assert "Multi-statement" in str(exc.value)
+
+
+@pytest.mark.parametrize("sql", [
+    "COMMIT; INSERT INTO t VALUES (1)",
+    "END; DROP TABLE t",
+])
+def test_multi_statement_escape_blocked_write(sql, cfg):
+    """DB-22172: same multi-statement rejection on the write path (regression
+    check — was already covered by DB-22131 multi-statement tests, but explicit
+    for the DB-22172 scenario)."""
+    with pytest.raises(QueryBlockedError) as exc:
+        validate_query(sql, cfg, read_only=False)
+    assert "Multi-statement" in str(exc.value)
+
+
+def test_bare_commit_alone_not_multi_statement(cfg):
+    """A lone COMMIT is one statement — not blocked by the multi-statement
+    check. (It's still harmless via the read tool: ends an empty read-only
+    txn.) Documents current behavior; if we want to also block bare
+    transaction control statements, that's a follow-up ticket."""
+    # No raise expected: single statement, not on the blocklist.
+    validate_query("COMMIT", cfg, read_only=True)
+    validate_query("END", cfg, read_only=True)
+    validate_query("ROLLBACK", cfg, read_only=True)

--- a/tests/test_integration_reads.py
+++ b/tests/test_integration_reads.py
@@ -16,8 +16,38 @@ pytestmark = [requires_yugabytedb, pytest.mark.asyncio]
 
 async def test_run_read_only_query_simple(mcp_session):
     result = await mcp_session.call_tool("run_read_only_query", {"query": "SELECT 1 AS x"})
-    rows = parse_json_list(result)
-    assert rows == [{"x": 1}]
+    parsed = parse_json_list(result)
+    assert parsed == {"columns": ["x"], "rows": [[1]]}
+
+
+async def test_run_read_only_query_duplicate_column_names(mcp_session):
+    """DB-22203: duplicate output column names must not collapse. Previously
+    `dict(zip(cols, row))` silently dropped the first `id`. Now columns and
+    rows are parallel arrays so all values survive."""
+    result = await mcp_session.call_tool(
+        "run_read_only_query",
+        {"query": "SELECT 1 AS id, 2 AS id, 3 AS other"},
+    )
+    parsed = parse_json_list(result)
+    assert parsed == {"columns": ["id", "id", "other"], "rows": [[1, 2, 3]]}
+
+
+async def test_run_read_only_query_join_star_no_column_loss(mcp_session, test_schema, db_conn):
+    """DB-22203 real-world repro: SELECT * over a join where both tables have
+    an `id` column. Both `id` values must be present, not collapsed."""
+    with db_conn.cursor() as cur:
+        cur.execute(f'CREATE TABLE "{test_schema}".a (id INT, tag TEXT)')
+        cur.execute(f'CREATE TABLE "{test_schema}".b (id INT, note TEXT)')
+        cur.execute(f'INSERT INTO "{test_schema}".a VALUES (1, \'left\')')
+        cur.execute(f'INSERT INTO "{test_schema}".b VALUES (2, \'right\')')
+
+    result = await mcp_session.call_tool(
+        "run_read_only_query",
+        {"query": f'SELECT * FROM "{test_schema}".a, "{test_schema}".b'},
+    )
+    parsed = parse_json_list(result)
+    assert parsed["columns"] == ["id", "tag", "id", "note"]
+    assert parsed["rows"] == [[1, "left", 2, "right"]]
 
 
 async def test_run_read_only_query_error_path(mcp_session):

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -1,14 +1,10 @@
-"""Unit tests for MCP tool registration — DB-22130.
+"""Unit tests for MCP tool registration.
 
-Verifies that `run_read_only_query` is advertised with `readOnlyHint=False,
-destructiveHint=True` so MCP clients (Claude Desktop, Cursor, ...) present
-the destructive-action confirmation prompt. Prior to the fix the tool was
-annotated `readOnlyHint=True` even though it can modify its environment
-(COPY, dblink, side-effecting functions — see DB-22129 blocklist), so
-clients skipped the confirmation.
-
-Also verifies:
-- `summarize_database` keeps `readOnlyHint=True` (it truly is read-only).
+Verifies:
+- `summarize_database` and `run_read_only_query` are both `readOnlyHint=True,
+  destructiveHint=False`. `run_read_only_query`'s guardrail (DB-22129) strips
+  the dangerous-function surface before execution, so the tool's advertised
+  read-only semantic holds.
 - `run_write_query` is gated behind `enable_write_query` and carries the
   destructive annotation when enabled.
 """
@@ -86,38 +82,24 @@ def _get_tool(mcp, name):
 
 
 # ---------------------------------------------------------------------------
-# DB-22130: run_read_only_query annotation must be destructive
+# run_read_only_query: read-only annotation (guardrail-backed)
 # ---------------------------------------------------------------------------
 
 class TestReadToolAnnotation:
-    """DB-22130 — run_read_only_query was `readOnlyHint=True` but it can
-    modify its environment (COPY, dblink, pg_read_file, etc. — see DB-22129).
-    MCP clients trusting readOnlyHint skipped the confirmation prompt. Fix:
-    flip to `readOnlyHint=False, destructiveHint=True, idempotentHint=True`."""
+    """`run_read_only_query`'s dangerous-function blocklist (DB-22129) strips
+    the RCE / file-read / dblink / set_config / privileged-catalog surface
+    before execution, so the tool truly is read-only end-to-end. Advertise
+    accordingly."""
 
-    def test_read_only_query_is_not_read_only_hint(self, with_config):
+    def test_read_only_query_is_read_only_hint(self, with_config):
         server = YugabyteDBMCPServer()
         tool = _get_tool(server.mcp, "run_read_only_query")
-        assert tool.annotations.readOnlyHint is False, (
-            "DB-22130: run_read_only_query must not advertise readOnlyHint=True — "
-            "MCP clients skip the confirmation prompt for readOnly tools."
-        )
+        assert tool.annotations.readOnlyHint is True
 
-    def test_read_only_query_is_destructive_hint(self, with_config):
+    def test_read_only_query_is_not_destructive_hint(self, with_config):
         server = YugabyteDBMCPServer()
         tool = _get_tool(server.mcp, "run_read_only_query")
-        assert tool.annotations.destructiveHint is True, (
-            "DB-22130: run_read_only_query must advertise destructiveHint=True "
-            "so clients present the destructive-action confirmation."
-        )
-
-    def test_read_only_query_is_idempotent_hint(self, with_config):
-        server = YugabyteDBMCPServer()
-        tool = _get_tool(server.mcp, "run_read_only_query")
-        # Idempotent because BEGIN READ ONLY + rollback means re-running the
-        # same allowed query has no side effect. The AST blocklist rejects
-        # side-effecting statements before execution.
-        assert tool.annotations.idempotentHint is True
+        assert tool.annotations.destructiveHint is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -1,0 +1,160 @@
+"""Unit tests for MCP tool registration — DB-22130.
+
+Verifies that `run_read_only_query` is advertised with `readOnlyHint=False,
+destructiveHint=True` so MCP clients (Claude Desktop, Cursor, ...) present
+the destructive-action confirmation prompt. Prior to the fix the tool was
+annotated `readOnlyHint=True` even though it can modify its environment
+(COPY, dblink, side-effecting functions — see DB-22129 blocklist), so
+clients skipped the confirmation.
+
+Also verifies:
+- `summarize_database` keeps `readOnlyHint=True` (it truly is read-only).
+- `run_write_query` is gated behind `enable_write_query` and carries the
+  destructive annotation when enabled.
+"""
+import asyncio
+from dataclasses import replace
+
+import pytest
+
+from yugabytedb_mcp_server import server as server_module
+from yugabytedb_mcp_server.server import ServerConfig, YugabyteDBMCPServer
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_BASE_CONFIG = ServerConfig(
+    yugabytedb_url="host=localhost port=5433 user=yugabyte dbname=yugabyte",
+    transport="stdio",
+    stateless_http=False,
+    ssl_root_cert_secret_arn=None,
+    ssl_root_cert_key=None,
+    ssl_root_cert_path="/tmp/yb-root.crt",
+    ssl_root_cert_secret_region=None,
+    max_insert_rows=1000,
+    require_where_on_update=False,
+    require_where_on_delete=False,
+    auth_provider=None,
+    enable_write_query=False,
+    identity_claim="email",
+    identity_transform="none",
+)
+
+
+@pytest.fixture
+def with_config():
+    """Set the module-level CONFIG so `YugabyteDBMCPServer()` can register
+    tools without going through `main()` / `parse_config()`."""
+    original = getattr(server_module, "CONFIG", None)
+    server_module.CONFIG = _BASE_CONFIG
+    yield
+    if original is None:
+        try:
+            del server_module.CONFIG
+        except AttributeError:
+            pass
+    else:
+        server_module.CONFIG = original
+
+
+@pytest.fixture
+def with_write_enabled():
+    """Same as with_config but with enable_write_query=True."""
+    original = getattr(server_module, "CONFIG", None)
+    server_module.CONFIG = replace(_BASE_CONFIG, enable_write_query=True)
+    yield
+    if original is None:
+        try:
+            del server_module.CONFIG
+        except AttributeError:
+            pass
+    else:
+        server_module.CONFIG = original
+
+
+def _get_tool(mcp, name):
+    """Look up a registered tool by name via `list_tools()`."""
+    tools = asyncio.run(mcp.list_tools())
+    for t in tools:
+        if t.name == name:
+            return t
+    raise AssertionError(
+        f"tool {name!r} not registered; got {[t.name for t in tools]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# DB-22130: run_read_only_query annotation must be destructive
+# ---------------------------------------------------------------------------
+
+class TestReadToolAnnotation:
+    """DB-22130 — run_read_only_query was `readOnlyHint=True` but it can
+    modify its environment (COPY, dblink, pg_read_file, etc. — see DB-22129).
+    MCP clients trusting readOnlyHint skipped the confirmation prompt. Fix:
+    flip to `readOnlyHint=False, destructiveHint=True, idempotentHint=True`."""
+
+    def test_read_only_query_is_not_read_only_hint(self, with_config):
+        server = YugabyteDBMCPServer()
+        tool = _get_tool(server.mcp, "run_read_only_query")
+        assert tool.annotations.readOnlyHint is False, (
+            "DB-22130: run_read_only_query must not advertise readOnlyHint=True — "
+            "MCP clients skip the confirmation prompt for readOnly tools."
+        )
+
+    def test_read_only_query_is_destructive_hint(self, with_config):
+        server = YugabyteDBMCPServer()
+        tool = _get_tool(server.mcp, "run_read_only_query")
+        assert tool.annotations.destructiveHint is True, (
+            "DB-22130: run_read_only_query must advertise destructiveHint=True "
+            "so clients present the destructive-action confirmation."
+        )
+
+    def test_read_only_query_is_idempotent_hint(self, with_config):
+        server = YugabyteDBMCPServer()
+        tool = _get_tool(server.mcp, "run_read_only_query")
+        # Idempotent because BEGIN READ ONLY + rollback means re-running the
+        # same allowed query has no side effect. The AST blocklist rejects
+        # side-effecting statements before execution.
+        assert tool.annotations.idempotentHint is True
+
+
+# ---------------------------------------------------------------------------
+# summarize_database: regression — must stay read-only
+# ---------------------------------------------------------------------------
+
+class TestSummarizeAnnotation:
+    """Regression: `summarize_database` is genuinely read-only (only queries
+    information_schema + COUNT(*)) — keep readOnlyHint=True."""
+
+    def test_summarize_database_read_only_hint(self, with_config):
+        server = YugabyteDBMCPServer()
+        tool = _get_tool(server.mcp, "summarize_database")
+        assert tool.annotations.readOnlyHint is True
+
+    def test_summarize_database_not_destructive(self, with_config):
+        server = YugabyteDBMCPServer()
+        tool = _get_tool(server.mcp, "summarize_database")
+        assert tool.annotations.destructiveHint is False
+
+
+# ---------------------------------------------------------------------------
+# run_write_query: gated behind enable_write_query
+# ---------------------------------------------------------------------------
+
+class TestWriteToolRegistration:
+
+    def test_write_query_not_registered_by_default(self, with_config):
+        """Default config has enable_write_query=False → tool is not exposed."""
+        server = YugabyteDBMCPServer()
+        tools = asyncio.run(server.mcp.list_tools())
+        names = {t.name for t in tools}
+        assert "run_write_query" not in names
+
+    def test_write_query_registered_when_enabled(self, with_write_enabled):
+        server = YugabyteDBMCPServer()
+        tool = _get_tool(server.mcp, "run_write_query")
+        assert tool.annotations.readOnlyHint is False
+        assert tool.annotations.destructiveHint is True
+        assert tool.annotations.idempotentHint is False

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,0 +1,205 @@
+"""Unit tests for _sanitize_for_json in tools.py.
+
+Covers DB-22157 (NaN/Infinity produced invalid JSON tokens; bytea was
+rendered as lossy Python repr). Also acts as a regression harness for the
+existing default=str fallthrough (datetime/Decimal/UUID/IPv4Address).
+
+The tool's runtime path is:
+
+    json.dumps(_sanitize_for_json(rows), allow_nan=False, default=str)
+
+`_sanitize_for_json` recursively converts non-JSON-safe values before
+`json.dumps` sees them; `allow_nan=False` then guarantees the emitted
+string is RFC-8259-valid JSON that strict parsers (JS `JSON.parse`) accept.
+"""
+import json
+from datetime import date, datetime, timezone
+from decimal import Decimal
+from ipaddress import IPv4Address
+from uuid import UUID
+
+import pytest
+
+from yugabytedb_mcp_server.tools import _sanitize_for_json
+
+
+# ---------------------------------------------------------------------------
+# DB-22157: non-finite floats produce invalid JSON via bare NaN/Infinity tokens
+# ---------------------------------------------------------------------------
+
+class TestNonFiniteFloats:
+    """Non-finite float values (`nan`, `inf`, `-inf`) must serialize as `null`
+    — Python's `json.dumps` emits them as bare tokens which are invalid JSON
+    per RFC 8259 and rejected by strict parsers including JavaScript
+    `JSON.parse`."""
+
+    @pytest.mark.parametrize("value", [
+        float("nan"),
+        float("inf"),
+        float("-inf"),
+    ])
+    def test_non_finite_becomes_null(self, value):
+        assert _sanitize_for_json([{"v": value}]) == [{"v": None}]
+
+    def test_finite_floats_pass_through(self):
+        assert _sanitize_for_json([
+            {"v": 1.5},
+            {"v": -3.14},
+            {"v": 0.0},
+        ]) == [
+            {"v": 1.5},
+            {"v": -3.14},
+            {"v": 0.0},
+        ]
+
+    def test_nested_list_with_nan(self):
+        # array-typed columns (Postgres text[]/int[]/float[]) come back as
+        # Python lists — must recurse.
+        result = _sanitize_for_json([{"arr": [1.0, float("nan"), 3.0]}])
+        assert result == [{"arr": [1.0, None, 3.0]}]
+
+    def test_nested_dict_with_inf(self):
+        # jsonb columns come back as Python dicts — must recurse.
+        result = _sanitize_for_json([{"j": {"score": float("inf"), "ok": True}}])
+        assert result == [{"j": {"score": None, "ok": True}}]
+
+    def test_tuple_treated_as_list(self):
+        # Composite/row values come back as tuples — same recursion.
+        result = _sanitize_for_json({"row": (1, float("nan"), "x")})
+        assert result == {"row": [1, None, "x"]}
+
+
+# ---------------------------------------------------------------------------
+# DB-22157: bytea encoded as lossy Python repr via default=str
+# ---------------------------------------------------------------------------
+
+class TestBytesEncoding:
+    """`bytea` values were rendered as `"b'\\xde\\xad\\xbe\\xef'"` (Python
+    bytes-repr) — lossy and not a defined encoding. Now encoded as
+    `{"$hex": "deadbeef"}` for a lossless, well-defined round-trip."""
+
+    def test_bytes_to_hex(self):
+        assert _sanitize_for_json([{"b": b"\xde\xad\xbe\xef"}]) == [
+            {"b": {"$hex": "deadbeef"}}
+        ]
+
+    def test_bytearray_to_hex(self):
+        assert _sanitize_for_json([{"b": bytearray(b"\x00\xff")}]) == [
+            {"b": {"$hex": "00ff"}}
+        ]
+
+    def test_memoryview_to_hex(self):
+        assert _sanitize_for_json([{"b": memoryview(b"abc")}]) == [
+            {"b": {"$hex": "616263"}}
+        ]
+
+    def test_empty_bytes(self):
+        assert _sanitize_for_json([{"b": b""}]) == [{"b": {"$hex": ""}}]
+
+    def test_bytes_inside_nested_structure(self):
+        result = _sanitize_for_json([{"outer": [b"\x01\x02"]}])
+        assert result == [{"outer": [{"$hex": "0102"}]}]
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: sanitize + json.dumps(allow_nan=False) round-trips through
+# strict parsers.
+# ---------------------------------------------------------------------------
+
+class TestStrictJSONRoundtrip:
+    """The runtime path uses `allow_nan=False` — an unsanitized NaN raises
+    `ValueError` even from a `default=` hook. These tests verify the
+    combined pipeline emits valid JSON for realistic query result shapes."""
+
+    def test_nan_and_bytea_together(self):
+        fixture = [
+            {"score": float("nan"), "blob": b"\xde\xad", "ok": True},
+            {"score": 42.5, "blob": b"", "ok": False},
+        ]
+        rendered = json.dumps(
+            _sanitize_for_json(fixture), allow_nan=False,
+        )
+        assert json.loads(rendered) == [
+            {"score": None, "blob": {"$hex": "dead"}, "ok": True},
+            {"score": 42.5, "blob": {"$hex": ""}, "ok": False},
+        ]
+
+    def test_allow_nan_false_never_raises_after_sanitize(self):
+        """Regression: previously json.dumps(NaN, allow_nan=False) raised
+        ValueError. After sanitize, allow_nan=False is safe on any input
+        with NaN/Inf mixed in."""
+        fixture = [{"a": float("nan"), "b": [float("inf"), float("-inf")]}]
+        # If sanitize missed a value, this would raise:
+        json.dumps(_sanitize_for_json(fixture), allow_nan=False)
+
+
+# ---------------------------------------------------------------------------
+# Regression: existing default=str coverage must not regress
+# ---------------------------------------------------------------------------
+
+class TestFallthroughToDefaultStr:
+    """The pre-fix code used `json.dumps(result, default=str)` which handled
+    datetime/Decimal/UUID/IPv4Address by stringifying. The new sanitizer must
+    not consume those types — they fall through to `default=str` unchanged."""
+
+    def test_datetime_passes_through_untouched(self):
+        dt = datetime(2026, 7, 10, 12, 0, tzinfo=timezone.utc)
+        sanitized = _sanitize_for_json([{"t": dt}])
+        # sanitizer leaves the datetime as a datetime object
+        assert isinstance(sanitized[0]["t"], datetime)
+        # json.dumps default=str stringifies it
+        rendered = json.dumps(sanitized, default=str)
+        assert "2026-07-10" in rendered
+
+    def test_date_passes_through(self):
+        rendered = json.dumps(_sanitize_for_json([{"d": date(2026, 7, 10)}]), default=str)
+        assert "2026-07-10" in rendered
+
+    def test_decimal_passes_through(self):
+        rendered = json.dumps(_sanitize_for_json([{"n": Decimal("3.14")}]), default=str)
+        assert "3.14" in rendered
+
+    def test_uuid_passes_through(self):
+        u = UUID("12345678-1234-5678-1234-567812345678")
+        rendered = json.dumps(_sanitize_for_json([{"u": u}]), default=str)
+        assert "12345678-1234-5678-1234-567812345678" in rendered
+
+    def test_ipv4_passes_through(self):
+        rendered = json.dumps(
+            _sanitize_for_json([{"ip": IPv4Address("192.168.1.1")}]),
+            default=str,
+        )
+        assert "192.168.1.1" in rendered
+
+
+# ---------------------------------------------------------------------------
+# Recursion depth / empty structures / primitives
+# ---------------------------------------------------------------------------
+
+class TestEdgeCases:
+
+    def test_empty_list(self):
+        assert _sanitize_for_json([]) == []
+
+    def test_empty_dict(self):
+        assert _sanitize_for_json({}) == {}
+
+    def test_primitive_string(self):
+        assert _sanitize_for_json("hello") == "hello"
+
+    def test_primitive_int(self):
+        assert _sanitize_for_json(42) == 42
+
+    def test_primitive_bool(self):
+        assert _sanitize_for_json(True) is True
+        assert _sanitize_for_json(False) is False
+
+    def test_none(self):
+        assert _sanitize_for_json(None) is None
+
+    def test_deeply_nested(self):
+        # 4-level nested structure with a NaN at the bottom
+        result = _sanitize_for_json(
+            {"a": {"b": [{"c": [float("nan")]}]}}
+        )
+        assert result == {"a": {"b": [{"c": [None]}]}}

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -203,3 +203,53 @@ class TestEdgeCases:
             {"a": {"b": [{"c": [float("nan")]}]}}
         )
         assert result == {"a": {"b": [{"c": [None]}]}}
+
+
+# ---------------------------------------------------------------------------
+# DB-22203: run_read_only_query response shape must not use dict(zip(cols, row))
+# ---------------------------------------------------------------------------
+
+class TestReadResultShape:
+    """DB-22203: previously `run_read_only_query` returned
+    `[dict(zip(cols, row)) for row in rows]`, which silently dropped
+    duplicate column names (e.g. `SELECT * FROM a, b` where both tables
+    have `id`, or `SELECT 1 AS id, 2 AS id`). The new shape is
+    `{"columns": [...], "rows": [[...], ...]}` — parallel arrays that
+    cannot collide.
+
+    These unit tests build the shape directly (no DB required) and verify:
+    - it round-trips through the sanitizer + json.dumps pipeline,
+    - duplicate column names survive,
+    - non-JSON-safe values in rows still get sanitized (NaN → None,
+      bytes → $hex).
+    """
+
+    def test_duplicate_column_names_preserved(self):
+        result = {"columns": ["id", "id", "other"], "rows": [[1, 2, 3]]}
+        sanitized = _sanitize_for_json(result)
+        assert sanitized == {"columns": ["id", "id", "other"], "rows": [[1, 2, 3]]}
+        # And valid JSON — three distinct positions, no dict-key collapse.
+        rendered = json.dumps(sanitized, allow_nan=False)
+        parsed = json.loads(rendered)
+        assert len(parsed["columns"]) == 3
+        assert len(parsed["rows"][0]) == 3
+
+    def test_empty_result_set(self):
+        result = {"columns": ["a", "b"], "rows": []}
+        assert _sanitize_for_json(result) == {"columns": ["a", "b"], "rows": []}
+
+    def test_rows_sanitized_recursively(self):
+        # NaN in one column, bytea in another — both must be normalized
+        # inside the row arrays.
+        result = {
+            "columns": ["score", "blob"],
+            "rows": [[float("nan"), b"\xde\xad"]],
+        }
+        sanitized = _sanitize_for_json(result)
+        assert sanitized == {
+            "columns": ["score", "blob"],
+            "rows": [[None, {"$hex": "dead"}]],
+        }
+        # Strict JSON survives.
+        rendered = json.dumps(sanitized, allow_nan=False)
+        assert json.loads(rendered) == sanitized


### PR DESCRIPTION
## Summary

Ships a unified `validate_query(sql, config, read_only: bool)` used by both `run_read_only_query` and `run_write_query`, fixing five audit bugs in one PR — the read-tool RCE / credential-disclosure surface, the read-only-transaction escape via multi-statement input, the write-guardrail regex over/under-blocking, the invalid JSON on `NaN` / `bytea`, and the duplicate-column-name collapse in the read-tool response shape.

Rename `validate_write_query` → `validate_query` rather than adding a near-duplicate `validate_read_query`.

### Bugs closed

- **[DB-22129](https://yugabyte.atlassian.net/browse/DB-22129)** [Highest] — `run_read_only_query` was executing arbitrary SQL with no validation. Now runs through the same blocklist as `run_write_query`, rejecting `COPY … TO PROGRAM`, `pg_read_file`, `dblink`, `pg_sleep`, `lo_import` / `lo_export`, `set_config`, and reads of privileged catalog tables (`pg_authid`, `pg_shadow`, `pg_user_mappings`, `pg_statistic`) before the query reaches the DB. Table detection reuses the AST walker: any bare `Name` token matching the privileged-catalog set is rejected — string literals and double-quoted identifiers tokenize differently and don't match. Schema-qualified references (`pg_catalog.pg_authid`) are caught because sqlparse emits the unqualified name as its own Name token.
- **[DB-22172](https://yugabyte.atlassian.net/browse/DB-22172)** [High] — `run_read_only_query` accepted multi-statement input; a batch starting with `COMMIT` or `END` closed the `BEGIN READ ONLY` wrapper and every subsequent statement auto-committed outside read-only. Fix: `validate_query` rejects any input with more than one statement (via `sqlparse.split`) before it reaches the DB. Applies on both the read and write paths. Repro (`COMMIT; INSERT INTO t VALUES (1)`, `END; DROP TABLE t`, etc.) is now `blocked_by_guardrail: true`.
- **[DB-22131](https://yugabyte.atlassian.net/browse/DB-22131)** [Medium] — the write guardrail's regex-on-raw-text produced (A) false positives (keywords inside string literals blocked legit writes like `INSERT INTO audit VALUES ('grant access')`) and (B) trivial bypasses (`set_config('search_path', …)`, `DO LANGUAGE plpgsql $$…$$`). Fix: replaced the regex blocklist with an AST walker over `sqlparse.parse(sql)`. Keyword pairs match on `Token.Keyword` / `Keyword.DDL` / `Keyword.DML` / `Keyword.DCL` tokens only, so keywords inside `String.Single` / `String.Symbol` don't match. Function calls detected as `Name` tokens immediately followed by `(` — catches dotted forms like `pg_catalog.pg_read_file(…)`. INSERT row-limit uses the parse tree's `Values` group children instead of `)(` char-counting. Top-level `WHERE` detection uses `Where` group placement, so `SET memo='reset where needed'` no longer satisfies `require_where_on_update`.
- **[DB-22157](https://yugabyte.atlassian.net/browse/DB-22157)** [Medium] — replace `json.dumps(result, indent=2, default=str)` with a recursive `_sanitize_for_json` pre-pass + `allow_nan=False`. Non-finite floats (`NaN` / `Infinity` / `-Infinity`) serialize as `null` (valid JSON — strict parsers including JS `JSON.parse` no longer reject the response). `bytes` / `memoryview` serialize as `{"$hex": "deadbeef"}` for a lossless round-trip. `datetime` / `Decimal` / `UUID` / `IPv4Address` still fall through to `default=str` (no regression).
- **[DB-22203](https://yugabyte.atlassian.net/browse/DB-22203)** [Medium] — `run_read_only_query` returned `[dict(zip(cols, row)) for row in rows]`, which silently dropped duplicate output column names. `SELECT 1 AS id, 2 AS id` returned `[{"id": 2}]` — the first `id` was lost with no warning and `is_error` false. Same collapse for `SELECT *` over a join where both tables have an `id` column. Fix: response shape is now `{"columns": [<name>, ...], "rows": [[<val>, ...], ...]}` — parallel arrays, no dict-key collision, duplicate column names survive losslessly. **Breaking change to the read-tool response format.**

DB-22130 (`run_read_only_query` annotation) was previously part of this PR and has been reverted per review feedback — the tool keeps `readOnlyHint: true, destructiveHint: false` because the DB-22129 guardrail strips the dangerous-function surface before execution, so the read-only semantic holds end-to-end.

### Design note

Used a single `validate_query(sql, config, read_only: bool)` rather than a `validate_read_query` wrapper — avoids duplicating the blocklist across two near-identical functions. The dangerous-function + privileged-catalog + multi-statement checks run in both modes; the write-shape checks (INSERT row limit, require-WHERE) are gated on `read_only=False`.

## Test plan

- [x] `uv run pytest tests/test_guardrails.py` — 141 tests pass (includes the new privileged-catalog blocklist coverage: 11 blocked-repro cases + 6 false-positive-absence cases).
- [x] `uv run pytest tests/test_serialization.py` — 22 tests pass (19 for DB-22157 + 3 for DB-22203).
- [x] `uv run pytest tests/ --ignore-glob=tests/test_integration_*.py` — 213 unit tests pass.
- [x] Integration suite against local YugabyteDB — 23/23 pass.
- [x] Live-server verification via MCP stdio session (25/25 probes): every DB-22129 example blocked including `pg_authid` / `pg_catalog.pg_authid` / `pg_shadow` / `pg_user_mappings` / `pg_statistic`; DB-22172 multi-statement escapes all blocked; DB-22203 duplicate-column repro returns `{"columns": ["id","id","other"], "rows": [[1,2,3]]}`; DB-22157 `NaN`/`Infinity`/bytea round-trip through strict JSON; DB-22131 false-positives no longer blocked and previous bypasses (`set_config`, `DO LANGUAGE plpgsql`) now blocked.