### PR TITLE
OIDC v2 identity mapping + JWT audience validation (DB-22135/174/192/136)

### DIFF
--- a/OIDC.md
+++ b/OIDC.md
@@ -1,0 +1,695 @@
+# OIDC authentication and per-user identity mapping
+
+Everything the yugabytedb-mcp-server does with OIDC lives in this document —
+provider setup, environment variables, the JWT → Postgres-role mapping, the
+`/auth/login` shortcut, and security guidance. This is the single source of
+truth; the top-level `README.md` links here.
+
+Design north star: **parity with YSQL's native OIDC → PG role mapping**
+(`ysql_hba_conf_csv` + `ysql_ident_conf_csv` + `matching_claim_key`). If
+you've configured YSQL OIDC, the concepts and file format transfer directly.
+
+Reference: YugabyteDB YSQL OIDC docs — [oidc-authentication-aad](https://docs.yugabyte.com/stable/yugabyte-platform/security/authentication/oidc-authentication-aad/).
+
+---
+
+## Table of contents
+
+- [When to use it](#when-to-use-it)
+- [Quick start (v1 default: email + strip_domain)](#quick-start)
+- [Provider setup](#provider-setup)
+  - [AWS Cognito](#aws-cognito)
+  - [Generic OIDC](#generic-oidc)
+- [Environment variables](#environment-variables)
+- [Identity → PG role mapping](#identity--pg-role-mapping)
+  - [The mapping flow](#the-mapping-flow)
+  - [Claim types (scalar / list / dotted-path)](#claim-types)
+  - [The identity map file (pg_ident.conf format)](#the-identity-map-file)
+  - [List-valued claims and the `requested_role` parameter](#list-valued-claims)
+- [Worked examples](#worked-examples)
+  - [Example 1 — Cognito with `email` (v1 default)](#example-1)
+  - [Example 2 — Cognito with `cognito:groups` (access-token flow)](#example-2)
+  - [Example 3 — Keycloak with `realm_access.roles`](#example-3)
+  - [Example 4 — Azure AD with GUID-valued groups](#example-4)
+  - [Example 5 — Generic OIDC with a custom claim](#example-5)
+- [The `/auth/login` endpoint (Cognito password flow)](#the-authlogin-endpoint)
+- [Security guidance](#security-guidance)
+- [Migrating from v1 to v2](#migrating-from-v1-to-v2)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## When to use it
+
+Turn OIDC on in **HTTP transport** deployments where multiple humans (or
+agents authenticating as humans) share one MCP server and you want per-user
+authorization enforced at the database layer.
+
+- Stdio transport (`Claude Desktop --> yugabytedb-mcp-server`) has no
+  network — auth is unnecessary and the OIDC path is skipped.
+- HTTP transport without OIDC = the pool's connection role for every caller.
+- HTTP transport with OIDC = `SET ROLE <mapped-role>` per tool call → each
+  caller's SQL runs under their own database role. Combines with Postgres
+  row-level security, schema grants, and `GRANT`/`REVOKE`.
+
+---
+
+## Quick start
+
+The simplest working setup: AWS Cognito + `email` claim + `strip_domain`
+transform. Each Cognito user's email local-part becomes a Postgres role.
+
+```bash
+# 1. In Postgres — create one role per user and grant the pool user
+#    membership (so it can SET ROLE).
+psql -c "CREATE ROLE alice;    GRANT SELECT ON tbl TO alice;"
+psql -c "CREATE ROLE bob;      GRANT SELECT ON tbl TO bob;"
+psql -c "GRANT alice, bob TO yugabyte;"
+
+# 2. Configure the server.
+export MCP_AUTH_PROVIDER=cognito
+export MCP_BASE_URL=https://mcp.example.com
+export COGNITO_USER_POOL_ID=us-west-2_XXXXXXXX
+export COGNITO_AWS_REGION=us-west-2
+export COGNITO_CLIENT_ID=…
+export COGNITO_CLIENT_SECRET=…
+export YB_MCP_IDENTITY_CLAIM=email          # default; shown for clarity
+export YB_MCP_IDENTITY_TRANSFORM=strip_domain
+
+# 3. Run.
+yugabytedb-mcp --transport http
+```
+
+Result: a caller authenticating as `alice@example.com` gets `SET ROLE alice`
+on every tool call. `bob@example.com` gets `SET ROLE bob`. Neither can access
+the other's data (assuming Postgres grants are set up correctly).
+
+For access-token workflows, list-valued claims, and role allowlists via a
+map file, jump to the [Worked examples](#worked-examples).
+
+---
+
+## Provider setup
+
+Two providers are supported: `cognito` (tested end-to-end) and `oidc`
+(generic OIDC; wiring is in place, exercise at your own risk).
+
+### AWS Cognito
+
+Required env vars when `MCP_AUTH_PROVIDER=cognito`:
+
+| Env var | Description |
+|---|---|
+| `COGNITO_USER_POOL_ID` | Cognito user-pool ID (e.g. `us-west-2_XXXXXXXX`) |
+| `COGNITO_AWS_REGION` | AWS region of the user pool |
+| `COGNITO_CLIENT_ID` | App-client ID within the pool |
+| `COGNITO_CLIENT_SECRET` | App-client secret |
+
+The server treats `COGNITO_CLIENT_ID` as the expected token audience — a
+token minted for a different app client in the same pool is rejected once
+audience validation lands (PR #3 of the audit release).
+
+The Cognito app client should have `openid email profile` scopes enabled.
+If you want access-token-friendly claim types (`cognito:groups`, or a custom
+`custom:db_role`), configure Cognito to include them either via User Pool
+Groups or a Pre-Token-Generation Lambda trigger.
+
+### Generic OIDC
+
+Required env vars when `MCP_AUTH_PROVIDER=oidc`:
+
+| Env var | Description |
+|---|---|
+| `OIDC_CONFIG_URL` | Full URL of the provider's OIDC discovery document (`…/.well-known/openid-configuration`) |
+| `OIDC_CLIENT_ID` | Client ID registered with the provider |
+| `OIDC_CLIENT_SECRET` | Client secret |
+| `OIDC_AUDIENCE` | *(recommended)* Expected token audience. Currently forwarded to `OIDCProxy` only; verifier-side check lands in PR #3. |
+
+The MCP server delegates OIDC discovery, JWKS retrieval, and token
+verification to FastMCP's `JWTVerifier` + `OIDCProxy`. The mapping path
+below is provider-agnostic — configure `YB_MCP_IDENTITY_CLAIM` and
+optionally an identity map, and the rest of the flow is identical to
+Cognito's.
+
+---
+
+## Environment variables
+
+Full reference. Marked with **(v1)** if pre-existed before the v2 mapping
+release, **(v2)** if new.
+
+| Env var | CLI flag | Purpose |
+|---|---|---|
+| `MCP_AUTH_PROVIDER` | `--mcp-auth-provider` | `cognito`, `oidc`, or unset (auth disabled). |
+| `MCP_BASE_URL` | — | Public base URL the server is reachable at (used for OAuth redirects). Required when auth is enabled. |
+| `YB_MCP_IDENTITY_CLAIM` | `--identity-claim` | **(v1, v2-extended)** JWT claim carrying the user's identity. v2 accepts dotted paths like `realm_access.roles` and top-level names with colons like `cognito:groups`. Default: `email`. |
+| `YB_MCP_IDENTITY_TRANSFORM` | `--identity-transform` | **(v1)** `none` (default) or `strip_domain`. Applied only on the no-map path — the map file replaces it when configured. |
+| `YB_MCP_IDENTITY_MAP` | `--identity-map` | **(v2)** Path to a `pg_ident.conf`-style map file. When set, replaces the transform path. See [The identity map file](#the-identity-map-file). |
+| `YB_MCP_IDENTITY_MAP_NAME` | `--identity-map-name` | **(v2)** Which named map inside the file to apply. Default: `default`. |
+| `YB_MCP_REQUIRE_ACCESS_TOKEN` | — | **(v2, Cognito-only)** When `true`, reject tokens with `token_use != "access"` (rejects ID tokens and refresh tokens presented as bearers). Default: `false` for backward compat with `identity_claim=email` deployments that rely on ID tokens. See [Access-token vs ID-token](#access-token-vs-id-token). |
+
+Cognito-specific (only required when `MCP_AUTH_PROVIDER=cognito`) — see
+[AWS Cognito](#aws-cognito) above.
+
+Generic-OIDC-specific — see [Generic OIDC](#generic-oidc) above.
+
+---
+
+## Identity → PG role mapping
+
+### The mapping flow
+
+Every tool call goes through this pipeline:
+
+```
+JWT access token
+  │
+  ├─ (1) Verify signature + issuer  ────►  reject on failure (401)
+  │
+  ├─ (2) Extract the identity claim by name (`YB_MCP_IDENTITY_CLAIM`)
+  │      └─ Dotted paths walk nested dicts: `realm_access.roles`
+  │      └─ Colons stay literal: `cognito:groups` is one key, not two
+  │
+  ├─ (3) Normalize to a list of raw string values
+  │      └─ Scalar claim: `email = "alice@…"` → `["alice@…"]`
+  │      └─ List claim: `groups = ["writer","reader"]` → `["writer","reader"]`
+  │
+  ├─ (4) Resolve each raw value to a candidate DB role
+  │      ├─ If `YB_MCP_IDENTITY_MAP` is set:
+  │      │    apply the map — literal or regex lookup per entry.
+  │      │    Unmapped values are dropped (not fallen through).
+  │      └─ Otherwise:
+  │           apply `YB_MCP_IDENTITY_TRANSFORM` (`none` or `strip_domain`).
+  │
+  ├─ (5) Pick one candidate
+  │      ├─ 0 candidates → IdentityError (fail-closed)
+  │      ├─ 1 candidate → auto-pick
+  │      └─ ≥2 candidates → agent must pass `requested_role`;
+  │           server clamps against the candidate list.
+  │
+  └─ (6) SET ROLE <picked>   (via psycopg.sql.Identifier — always quoted)
+```
+
+Two error modes:
+
+- **`IdentityError`** (returned to the client as a clean error) — the token
+  is valid but has no usable claim, no candidate resolves, or
+  `requested_role` isn't in the candidate list. Fail-closed: never falls
+  through to pool credentials.
+- **`SET ROLE` failure** at the DB layer — the mapped role doesn't exist,
+  or the pool user doesn't have `GRANT` on it. Currently surfaces as a
+  `ToolError`; DB-22175 tracks turning this into a clean `IdentityError`.
+
+### Claim types
+
+Three claim shapes work end-to-end.
+
+**Scalar** (single string value):
+
+```json
+{
+  "sub": "5ac1e1a0-f8d3-4d5c-9a2b-8c73f4e2b3a1",
+  "email": "alice@example.com",
+  "preferred_username": "alice"
+}
+```
+
+Any of these can be the identity claim. Configure via
+`YB_MCP_IDENTITY_CLAIM=email` (or `sub`, or `preferred_username`).
+
+**List** (array of strings — usually roles/groups):
+
+```json
+{
+  "cognito:groups": ["writer", "reader"],
+  "realm_access": {
+    "roles": ["app-writer", "app-reader"]
+  },
+  "groups": ["a12d04b1-7463-…", "c22b03b1-2746-…"]
+}
+```
+
+Configure via `YB_MCP_IDENTITY_CLAIM=cognito:groups` (Cognito),
+`realm_access.roles` (Keycloak), or `groups` (Azure AD). The caller (agent)
+picks one via `requested_role` — see [List-valued claims](#list-valued-claims).
+
+**Dotted path** — the identity claim can walk nested dict structure:
+
+- `realm_access.roles` → `claims["realm_access"]["roles"]`
+- `a.b.c` → `claims["a"]["b"]["c"]`
+- `cognito:groups` — NO walk (colon is a literal key char) →
+  `claims["cognito:groups"]`
+
+Missing intermediate keys raise `IdentityError` with the exact path that
+failed.
+
+### The identity map file
+
+`YB_MCP_IDENTITY_MAP=/etc/yb-mcp/ident.conf` points at a text file with the
+same format YSQL uses for `ysql_ident_conf_csv` and PostgreSQL uses for
+`pg_ident.conf`.
+
+**Syntax:**
+
+```
+# Each non-empty, non-comment line has three space-separated fields:
+#   <map_name>  <system_value>  <db_role>
+#
+# `#` starts a comment (line or trailing).
+# Blank lines are ignored.
+# `system_value` starting with `/` is a regex — the rest of the field
+# (no closing `/`) is the pattern. Match is anchored (fullmatch).
+# `\1`, `\2`, ... in `db_role` reference regex capture groups.
+
+# Literal mapping:
+default  user@yugabyte.com                                     user
+default  bob@yugabyte.com                                      writer
+default  reader@yugabyte.com                                   reader
+
+# Regex mapping with capture group:
+default  /^(.*)@yugabyte\.com$                                 \1
+
+# Role-name mapping (Keycloak realm-role name → DB role name):
+default  app-writer                                            writer
+default  app-reader                                            reader
+
+# Azure AD GUID → readable role name (YSQL docs note: GUIDs need regex):
+azure    /^a12d04b1-.+                                         reader
+azure    /^c22b03b1-.+                                         writer
+
+# Cognito custom-claim OIDC group name → PG role:
+cognito  OIDC.Test.Read                                        read_only_user
+```
+
+**Multiple named maps** — one file can carry entries for `default`,
+`azure`, `cognito`, and any custom name. `YB_MCP_IDENTITY_MAP_NAME`
+selects which one to apply at runtime (default: `default`). Entries under
+other names are loaded but never consulted — useful for switching between
+IdPs by env-var flip.
+
+**Fail-closed** — a syntactically bad line (missing field count, invalid
+regex, unreadable file) makes the server refuse to start. A typo doesn't
+silently widen access.
+
+**Match order** — entries are iterated in file order; the first match under
+the active `map_name` wins. Put more-specific entries above catch-all
+regexes.
+
+**No fallback** — if the map has no entry that matches the claim value,
+that value is dropped from the candidate list. If no value in a list-claim
+resolves, `IdentityError` fires. The map IS the allowlist.
+
+### List-valued claims
+
+Cognito's `cognito:groups`, Keycloak's `realm_access.roles`, and Azure AD's
+`groups` all come back as JSON arrays. The mapping semantics match YSQL's
+native behavior: *"the user can take any
+PG role that is in their roles/groups claim."*
+
+**How the tool interface exposes this:** every DB tool
+(`summarize_database`, `run_read_only_query`, `run_write_query`) accepts an
+optional `requested_role: str | None = None` parameter.
+
+- If the claim resolves to a single candidate → server ignores
+  `requested_role` and uses that candidate.
+- If the claim resolves to multiple candidates AND `requested_role` is in
+  the candidate list → server uses `requested_role`.
+- If the claim resolves to multiple candidates AND `requested_role` is
+  passed but NOT in the list → server raises `IdentityError`. The agent
+  cannot pick a role that isn't in its JWT's mapped candidates.
+- If the claim resolves to multiple candidates AND `requested_role` is
+  `None` → server auto-picks the first candidate and logs a `WARNING`.
+  Pass `requested_role` explicitly for deterministic behavior.
+- If the claim resolves to zero candidates → `IdentityError`.
+
+**How the agent picks:** the LLM invokes `run_read_only_query(..., 
+requested_role="reader")` after seeing the JWT's mapped candidate list.
+The server clamps — the agent cannot request a role that isn't in the JWT.
+
+---
+
+## Worked examples
+
+### Example 1
+
+**Cognito with `email` (v1 default; simplest case).**
+
+```bash
+export MCP_AUTH_PROVIDER=cognito
+export COGNITO_USER_POOL_ID=us-west-2_XXXXXXXX
+export COGNITO_AWS_REGION=us-west-2
+export COGNITO_CLIENT_ID=abc123
+export COGNITO_CLIENT_SECRET=…
+export YB_MCP_IDENTITY_CLAIM=email
+export YB_MCP_IDENTITY_TRANSFORM=strip_domain
+# YB_MCP_IDENTITY_MAP unset — v1 backward-compat path
+```
+
+For each Cognito user, create a matching Postgres role:
+
+```sql
+CREATE ROLE alice; GRANT alice TO yugabyte;
+CREATE ROLE bob;   GRANT bob   TO yugabyte;
+```
+
+A caller authenticating as `alice@example.com` runs SQL under `SET ROLE
+alice`.
+
+**Caveat** (DB-22192): Cognito ID tokens carry `email` but access tokens
+don't. Under this configuration the server needs to accept ID tokens. Once
+`token_use=access` enforcement lands (PR #3 opt-in), switch to Example 2.
+
+### Example 2
+
+**Cognito with `cognito:groups` (access-token workflow; recommended
+long-term).**
+
+Configure Cognito to add users to User Pool Groups (Console → User pools →
+Groups). Access tokens now carry `cognito:groups`:
+
+```json
+{
+  "sub": "…",
+  "token_use": "access",
+  "cognito:groups": ["writer", "reader"]
+}
+```
+
+Server config:
+
+```bash
+export YB_MCP_IDENTITY_CLAIM=cognito:groups
+# YB_MCP_IDENTITY_MAP optional — group names ARE the DB role names
+# unset means each group in the list is used as-is
+```
+
+Postgres setup — one role per group name:
+
+```sql
+CREATE ROLE writer; GRANT ...ON tbl TO writer; GRANT writer TO yugabyte;
+CREATE ROLE reader; GRANT SELECT ON tbl TO reader; GRANT reader TO yugabyte;
+```
+
+**Agent invocation** — the LLM sees two candidates and picks one:
+
+```json
+{
+  "name": "run_read_only_query",
+  "arguments": {
+    "query": "SELECT * FROM tbl",
+    "requested_role": "reader"
+  }
+}
+```
+
+Server-side flow: `_extract_claim` gets `["writer","reader"]` →
+`_apply_transform("none")` on each → candidates `["writer","reader"]` →
+`_pick_role(candidates, "reader")` returns `"reader"` → `SET ROLE reader`.
+
+### Example 3
+
+**Keycloak with `realm_access.roles` (dotted-path claim + map file).**
+
+Access token payload:
+
+```json
+{
+  "realm_access": {
+    "roles": ["app-writer", "offline_access", "default-roles-realm"]
+  }
+}
+```
+
+The realm has three roles but only one is meaningful for DB access
+(`app-writer`); the others are Keycloak boilerplate. Use a map to
+whitelist:
+
+```
+# /etc/yb-mcp/ident.conf
+default  app-writer  writer
+default  app-reader  reader
+```
+
+Server config:
+
+```bash
+export YB_MCP_IDENTITY_CLAIM=realm_access.roles
+export YB_MCP_IDENTITY_MAP=/etc/yb-mcp/ident.conf
+# YB_MCP_IDENTITY_MAP_NAME=default (implicit)
+```
+
+Server-side flow: `_extract_claim` walks
+`claims["realm_access"]["roles"]` → `["app-writer", "offline_access",
+"default-roles-realm"]` → `_apply_map` per element → `offline_access` and
+`default-roles-realm` don't match any map entry (dropped), `app-writer` →
+`writer`. Candidates = `["writer"]`, single candidate → auto-pick →
+`SET ROLE writer`.
+
+Keycloak boilerplate roles never reach the database. The map IS the
+allowlist.
+
+### Example 4
+
+**Azure AD with GUID-valued `groups` (regex map required).**
+
+Azure AD emits group memberships as opaque GUIDs, which aren't valid
+Postgres role identifiers. Use a regex map to translate them:
+
+```
+# /etc/yb-mcp/ident.conf
+azure  /^a12d04b1-.+   readonly_role
+azure  /^c22b03b1-.+   writable_role
+azure  /^9c8d4f3e-.+   admin_role
+```
+
+Access token payload:
+
+```json
+{
+  "groups": ["a12d04b1-7463-8e23-94d2-8d71f17ab99b"]
+}
+```
+
+Server config:
+
+```bash
+export YB_MCP_IDENTITY_CLAIM=groups
+export YB_MCP_IDENTITY_MAP=/etc/yb-mcp/ident.conf
+export YB_MCP_IDENTITY_MAP_NAME=azure
+```
+
+Server-side flow: `_extract_claim` → `["a12d04b1-..."]` → `_apply_map`
+regex hit on `/^a12d04b1-.+` → `readonly_role`. `SET ROLE readonly_role`.
+
+**Regex capture groups** for on-the-fly renaming — e.g. strip a common
+prefix from Azure group names:
+
+```
+azure  /^APP_YB_MCP_(.+)$   \1
+```
+
+`APP_YB_MCP_writer` → `writer`.
+
+### Example 5
+
+**Generic OIDC (e.g. Okta) with a custom claim.**
+
+Configure the IdP to inject a `db_role` claim into access tokens (or use
+`preferred_username` — a standard OIDC claim). Server config:
+
+```bash
+export MCP_AUTH_PROVIDER=oidc
+export OIDC_CONFIG_URL=https://okta.example.com/.well-known/openid-configuration
+export OIDC_CLIENT_ID=…
+export OIDC_CLIENT_SECRET=…
+export OIDC_AUDIENCE=…
+export YB_MCP_IDENTITY_CLAIM=db_role
+# No map — the custom claim already carries the role name.
+```
+
+If the IdP can't inject a custom claim, use `preferred_username` and map
+usernames via the map file.
+
+---
+
+## The `/auth/login` endpoint
+
+When `MCP_AUTH_PROVIDER=cognito`, the HTTP transport exposes an unauthenticated
+`POST /auth/login` that exchanges Cognito email + password for tokens. This is
+for curl-based smoke tests, CI pipelines, and scripted clients that can't run
+a browser OAuth flow.
+
+```bash
+curl -X POST http://localhost:8000/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"email": "alice@example.com", "password": "…"}'
+# → { "access_token": "...", "id_token": "...", "refresh_token": "...", ... }
+
+ACCESS_TOKEN=<from above>
+curl -H "Authorization: Bearer $ACCESS_TOKEN" http://localhost:8000/mcp
+```
+
+Requires the Cognito app client to have `ALLOW_USER_PASSWORD_AUTH` enabled
+(Console → User pools → App integration → App client settings). MFA,
+password-reset, and other challenge flows are not handled — those require the
+browser OAuth flow.
+
+Hardening gaps tracked in DB-22190 (uniform error detail — currently leaks
+whether the email exists) and DB-22191 (no app-level rate limiting; returns
+refresh token in the response body). Both scheduled for follow-up release.
+
+---
+
+## Security guidance
+
+### Least-privilege pool
+
+The pool DB user (whatever's in `YUGABYTEDB_URL`) must have `GRANT` on
+every role the identity mapping can reach — that's how `SET ROLE` works.
+Two approaches:
+
+1. **Least-privilege pool + map allowlist (recommended).** Pool user is a
+   normal role. Explicitly `GRANT` it membership in the target roles you
+   want reachable. Configure `YB_MCP_IDENTITY_MAP` — the map is the
+   allowlist; anything not in the map raises `IdentityError` before
+   `SET ROLE` runs.
+
+   ```sql
+   CREATE ROLE mcp_pool WITH LOGIN PASSWORD '…';
+   CREATE ROLE writer;
+   CREATE ROLE reader;
+   GRANT writer, reader TO mcp_pool;   -- pool can SET ROLE to these two
+   ```
+
+2. **Superuser pool (default, less safe).** Pool user is a Postgres
+   superuser (`yugabyte` is by default). `SET ROLE` can reach any role,
+   including superuser roles. Only safe if `YB_MCP_IDENTITY_MAP` is set —
+   the map bounds what roles can be reached even from a superuser pool.
+
+Without a map file AND a superuser pool, any authenticated user whose
+claim happens to spell an existing role name gets `SET ROLE` to that role —
+including superuser roles named after real users. This is DB-22135.
+
+### Why the map is an allowlist
+
+The map's `<system_value>` field is a whitelist. Values not matching any
+entry are dropped from the candidate list. If a list-valued claim's every
+value is unmapped, `IdentityError` fires — no fallback to pool credentials.
+
+This is why we recommend running with a map even for simple deployments:
+it turns the identity → role edge into an explicit, auditable list.
+
+### Identifier quoting
+
+Role names are always wrapped in `psycopg.sql.Identifier` before reaching
+`SET ROLE` — see `tools.py:95`. So even if a claim value or map output
+contained SQL-injection-shaped strings, they'd be safely quoted as an
+identifier. The map layer doesn't sanitize; the SQL layer does.
+
+### Access-token vs ID-token
+
+Cognito issues two tokens per authentication: an ID token (contains
+`email`, `preferred_username`, and other user attributes) and an access
+token (contains `sub`, `cognito:groups`, `token_use=access`; NO `email`).
+Standard OAuth 2.0 practice is to send access tokens to APIs, ID tokens to
+clients.
+
+Today the server doesn't enforce `token_use=access` — it accepts either.
+Once PR #3 lands with `YB_MCP_REQUIRE_ACCESS_TOKEN=true`, the ID-token
+path closes. To be ready:
+
+- Prefer identity claims present in access tokens (`sub`, `cognito:groups`,
+  custom claims via a Cognito Lambda). Don't rely on `email`.
+- Example 2 above is the recommended long-term shape.
+
+---
+
+## Migrating from v1 to v2
+
+The v2 mapping is fully backward-compatible. If `YB_MCP_IDENTITY_MAP` is
+unset, the server behaves exactly like v1 (email → strip_domain → role).
+
+Migration checklist for an existing deployment:
+
+1. **Enumerate your current roles.** `SELECT rolname FROM pg_roles WHERE …`.
+2. **Decide the claim source.** For access-token workflows, pick something
+   present in access tokens (`sub`, `cognito:groups`, custom claim). For
+   ID-token workflows continuing on `email`, no change needed yet.
+3. **Write the map file.** Start with literal entries for known users;
+   add a regex fallback if needed. Test the file parses locally:
+
+   ```bash
+   YB_MCP_IDENTITY_MAP=/path/to/ident.conf yugabytedb-mcp --transport stdio
+   # If the map is malformed, startup fails with a clear error.
+   ```
+
+4. **Deploy with the map**, keeping the old claim/transform envs as
+   fallback. When the map is set, transform is ignored.
+5. **Verify with a smoke test.** Use `/auth/login` or your normal auth
+   path, invoke a tool with `requested_role` set, confirm the SQL runs as
+   the expected role (`SELECT current_role` in a `run_read_only_query`).
+6. **(Optional) Switch claim source.** Change `YB_MCP_IDENTITY_CLAIM` to
+   an access-token-friendly value (e.g. `cognito:groups`), update the map
+   accordingly, re-verify.
+
+---
+
+## Troubleshooting
+
+**`IdentityError: Token present but required claim 'email' is missing or empty.`**
+The token is valid but has no value at the configured claim name. Common
+cause: an access token was presented where `identity_claim=email` (email is
+ID-token-only on Cognito). Fix: switch `identity_claim` to a claim present
+in access tokens (`sub`, `cognito:groups`), or accept ID tokens.
+
+**`IdentityError: None of the identity-claim values resolved to a permitted DB role.`**
+The claim is present but nothing in the (list of) values matches any entry
+in the map under the current `identity_map_name`. Check:
+- Is `YB_MCP_IDENTITY_MAP_NAME` the right map? (e.g. `default` vs `azure`).
+- Do the map's `<system_value>` fields exactly match what the IdP sends?
+  Print the raw JWT and inspect.
+- Is a regex missing an anchor? The match is anchored (fullmatch) — a
+  pattern like `/foo` will only match the exact string `foo`, not `foobar`.
+
+**`IdentityError: requested_role='admin' is not in the caller's identity-claim candidates [...]`**
+The agent passed a `requested_role` that isn't in the JWT's mapped list.
+By design — server clamps. Fix: agent picks a value from the candidates
+returned to it (or, if the agent is running blind, drop `requested_role`
+and let the server auto-pick with a WARNING).
+
+**`role "X" does not exist`** (as a `ToolError`, not `IdentityError`).
+The mapping produced a role name that Postgres doesn't have. Either
+create the role or fix the map. DB-22175 tracks converting this into a
+clean `IdentityError` at the tool layer.
+
+**Server refuses to start with `ValueError: /path/ident.conf:N: …`.**
+Fail-closed on a malformed map file. The line number and pattern are in
+the error message. Fix the file and restart.
+
+**`SET ROLE` succeeds but the user still can't read/write.**
+Postgres role membership vs. object-level `GRANT`s are separate. Confirm:
+```sql
+SELECT current_role;
+GRANT SELECT ON tbl TO reader;
+```
+
+---
+
+## YSQL parity reference (for engineers coming from YSQL native OIDC)
+
+The MCP server's mapping is designed to port cleanly from YSQL's native
+`ysql_hba_conf_csv` + `ysql_ident_conf_csv` + `matching_claim_key`
+approach. Rough equivalence:
+
+| YSQL native OIDC | MCP server v2 |
+|---|---|
+| `matching_claim_key` (in `ysql_hba_conf_csv`) | `YB_MCP_IDENTITY_CLAIM` env var |
+| `map=<name>` (in HBA line) | `YB_MCP_IDENTITY_MAP_NAME` env var |
+| `ysql_ident_conf_csv` file | `YB_MCP_IDENTITY_MAP` file (same format) |
+| YSQL `HandleValidationResultAndPopulateIdentityClaims` | `tools.py:_extract_claim` |
+| YSQL `GetJwtClaimAsStringsList` | `tools.py:_get_db_role` list-normalization |
+| YSQL `YBCValidateJWT` | Not called from MCP — FastMCP's `JWTVerifier` handles signature/issuer/audience |
+
+If you have a working `ysql_ident_conf_csv` file for a YSQL-native OIDC
+deployment, you can point `YB_MCP_IDENTITY_MAP` at the same file and it
+will parse identically.

--- a/OIDC.md
+++ b/OIDC.md
@@ -92,7 +92,10 @@ map file, jump to the [Worked examples](#worked-examples).
 ## Provider setup
 
 Two providers are supported: `cognito` (tested end-to-end) and `oidc`
-(generic OIDC; wiring is in place, exercise at your own risk).
+(generic OIDC; exercised via Keycloak by the tutorials under
+[`examples/oidc-auth/`](examples/oidc-auth/) and
+[`examples/oidc-auth-mapping/`](examples/oidc-auth-mapping/)). Any RFC 6749 /
+OIDC 1.0 compliant provider should work — only the connection details change.
 
 ### AWS Cognito
 

--- a/README.md
+++ b/README.md
@@ -68,9 +68,7 @@ For development from source, see [Development](#development) below.
 | `YB_MCP_REQUIRE_WHERE_ON_UPDATE` | `--require-where-on-update` | No | Reject UPDATE without a WHERE clause. Default `false`. |
 | `YB_MCP_REQUIRE_WHERE_ON_DELETE` | `--require-where-on-delete` | No | Reject DELETE without a WHERE clause. Default `false`. |
 | `YB_MCP_ENABLE_WRITE_QUERY` | `--enable-write-query` | No | Enable the `run_write_query` tool. Default `false` (write tool disabled). |
-| `MCP_AUTH_PROVIDER` | `--mcp-auth-provider` | No | `cognito` (tested) or `oidc` (untested). Leave unset to disable auth. |
-| `YB_MCP_IDENTITY_CLAIM` | `--identity-claim` | No | JWT claim to use as the DB role identifier for per-user `SET ROLE`. Default `email`. |
-| `YB_MCP_IDENTITY_TRANSFORM` | `--identity-transform` | No | Transform applied to the claim before using as a DB role: `none` (default) or `strip_domain` (strips `@…` from emails). |
+| `MCP_AUTH_PROVIDER` | `--mcp-auth-provider` | No | `cognito` or `oidc`. Leave unset to disable auth. Full OIDC/Cognito setup + per-user identity mapping is documented in [`OIDC.md`](OIDC.md). |
 | `MCP_BASE_URL` | — | When auth enabled | Public base URL the server is reachable at (e.g. `https://mcp.example.com`). |
 | `MCP_ALLOWED_ORIGINS` | — | No | Comma-separated allowlist of Origin values for DNS-rebinding defense. Defaults to `MCP_BASE_URL`. |
 | `YB_LOG_LEVEL` | — | No | Log level for the `yugabytedb-mcp` logger family (default `INFO`). |
@@ -79,14 +77,8 @@ For development from source, see [Development](#development) below.
 | `YB_AWS_SSL_ROOT_CERT_SECRET_REGION` | `--yb-aws-ssl-root-cert-secret-region` | No | AWS region of the secret. |
 | `YB_SSL_ROOT_CERT_PATH` | `--yb-ssl-root-cert-path` | No | Where to write the fetched cert. Default `/tmp/yb-root.crt`. |
 
-Cognito-specific env vars (only required when `MCP_AUTH_PROVIDER=cognito`):
-
-| Variable | Description |
-|---|---|
-| `COGNITO_USER_POOL_ID` | Cognito user-pool ID (e.g. `us-west-2_XXXXXXXX`) |
-| `COGNITO_AWS_REGION` | AWS region |
-| `COGNITO_CLIENT_ID` | App client ID |
-| `COGNITO_CLIENT_SECRET` | App client secret |
+For OIDC/Cognito authentication, per-user `SET ROLE` mapping, the identity map
+file format, and the `/auth/login` shortcut — see [`OIDC.md`](OIDC.md).
 
 A starter template is in `.env.example`.
 
@@ -180,7 +172,9 @@ This list is best-effort, not exhaustive. `destructiveHint: true` is the second 
 
 ## Self-hosted remote mode
 
-For multi-user or shared deployments, run the server as Streamable HTTP behind a reverse proxy with TLS, with Cognito OAuth gating access:
+For multi-user or shared deployments, run the server as Streamable HTTP behind a reverse proxy with TLS, with Cognito OAuth (or generic OIDC) gating access. The full setup — provider config, per-user `SET ROLE` mapping, the identity map file format, the `/auth/login` shortcut, and security guidance — is in [`OIDC.md`](OIDC.md).
+
+Minimum config for Cognito:
 
 ```bash
 export MCP_AUTH_PROVIDER=cognito
@@ -200,72 +194,8 @@ Behavior:
 - Requests to `/mcp` without a valid Bearer token return 401.
 - Requests with a disallowed `Origin` header return 403 (DNS-rebinding defense).
 - `/ping` is unauthenticated and is suitable for liveness probes.
-- `/auth/login` exposes a Cognito email+password → token shortcut (see below).
+- `/auth/login` exposes a Cognito email+password → token shortcut (details in [`OIDC.md`](OIDC.md)).
 - `--stateless-http` is required for multi-replica deployments — without it, MCP session state lives in process memory and round-robin load balancing breaks sessions.
-
-### Getting a token without a browser
-
-The browser-based OAuth flow is what Claude Desktop / mcp-remote / claude.ai use, but for curl-based smoke tests, CI, or any scripted client, the HTTP transport also exposes a direct password endpoint when `MCP_AUTH_PROVIDER=cognito`:
-
-```bash
-curl -X POST http://localhost:8000/auth/login \
-  -H "Content-Type: application/json" \
-  -d '{"email":"user@example.com","password":"…"}'
-# →
-# {"access_token":"…","id_token":"…","refresh_token":"…","expires_in":86400,"token_type":"Bearer"}
-```
-
-Then:
-
-```bash
-curl -H "Authorization: Bearer $ACCESS_TOKEN" \
-     -H "Accept: application/json,text/event-stream" \
-     -X POST http://localhost:8000/mcp \
-     -H "Content-Type: application/json" \
-     -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"curl","version":"1"}}}'
-```
-
-The endpoint uses Cognito's `USER_PASSWORD_AUTH` flow under the hood — the Cognito **app client must have `ALLOW_USER_PASSWORD_AUTH` enabled** (Cognito Console → User pools → App integration → App client settings). MFA, password-reset, and other challenge flows are **not** handled by this endpoint — they require the browser flow.
-
-OIDC (`MCP_AUTH_PROVIDER=oidc`) wiring exists but is untested; please share findings if you exercise it.
-
-### Per-user database roles (SET ROLE)
-
-When OIDC auth is enabled, the server can map each authenticated user to a YugabyteDB database role using `SET ROLE`. This enforces row-level security, schema-level grants, and per-user privilege boundaries — the same connection pool is used, but each tool call runs under the caller's database role.
-
-```bash
-export YB_MCP_IDENTITY_CLAIM=email             # JWT claim to extract (default)
-export YB_MCP_IDENTITY_TRANSFORM=strip_domain  # alice@example.com → alice
-```
-
-**How it works:**
-
-1. The server extracts the configured claim from the OIDC access token.
-2. An optional transform derives the DB role name (e.g., stripping `@domain`).
-3. Before executing tool SQL, the server issues `SET ROLE <role>` on the pooled connection.
-4. After execution, `RESET ROLE` restores the connection to the pool user.
-
-**Requirements:**
-
-- The pool user (from `YUGABYTEDB_URL`) must be a superuser **or** have `GRANT <target_role> TO <pool_user>` for every role that can authenticate.
-- Target roles must already exist in the database — the server does not create them.
-- When auth is disabled (no `MCP_AUTH_PROVIDER`), SET ROLE is not used and the pool operates with its configured credentials as before.
-
-**Example setup:**
-
-```sql
--- Create per-user roles matching the identity claim
-CREATE ROLE alice LOGIN;
-CREATE ROLE bob LOGIN;
-
--- Grant them to the pool user so SET ROLE works
-GRANT alice TO mcp_admin;
-GRANT bob TO mcp_admin;
-
--- Apply per-role permissions as needed
-GRANT SELECT ON ALL TABLES IN SCHEMA public TO alice;
-GRANT ALL ON ALL TABLES IN SCHEMA public TO bob;
-```
 
 ## AWS Secrets Manager for TLS certificates
 

--- a/examples/oidc-auth-mapping/README.md
+++ b/examples/oidc-auth-mapping/README.md
@@ -78,7 +78,7 @@ The realm's audience mapper also stamps `aud: yb-mcp-server` on every access tok
 
 ### View the realm in the admin console (optional)
 
-Open http://localhost:18081, sign in as `admin` / `admin`, and navigate to **Realm settings → yb-mcp-map**. Under **Realm roles** you'll see `db-writer` / `db-reader`. Under **Users**, each of the three demo users has role assignments visible on the **Role mapping** tab.
+Open http://localhost:18081, sign in as `admin` / `admin`, and select the realm yb-mcp-map from the drop down menu on the left side. Under **Realm roles**, you'll see `db-writer` / `db-reader`. Under **Users → <username>**, each of the three demo users has role assignments visible on the **Role mapping** tab.
 
 ## Step 2 — Seed the database
 

--- a/examples/oidc-auth-mapping/README.md
+++ b/examples/oidc-auth-mapping/README.md
@@ -1,0 +1,343 @@
+# OIDC identity-mapping tutorial — realm-role claim + map file + `requested_role`
+
+Companion to [`examples/oidc-auth/`](../oidc-auth/README.md). That tutorial proves per-user Postgres roles work end-to-end using the simplest possible claim (`email`) with a transform. **This** tutorial proves the same enforcement with the v2 identity-mapping additions:
+
+- **List-valued claim** — `realm_access.roles` is a JSON array, not a scalar
+- **Dotted-path claim extraction** — the server walks `realm_access` then `roles`
+- **Identity map file** — an allowlist that translates Keycloak realm-role names to Postgres role names AND drops Keycloak boilerplate roles (`offline_access`, `default-roles-*`, `uma_authorization`)
+- **`requested_role` on ambiguity** — a user whose token maps to more than one Postgres role picks explicitly per tool call
+
+The two tutorials run side-by-side without interfering — different Keycloak port (18081 vs 18080), different realm (`yb-mcp-map` vs `yb-mcp`), same Postgres roles (`writer` / `reader`), same demo table.
+
+## What you'll prove by the end
+
+> Three Keycloak users hit the **same MCP server, same connection pool, same `run_write_query` tool**. Their tokens carry Keycloak REALM ROLES (not emails). The MCP server runs those role names through a map file — Keycloak boilerplate roles are dropped, the two whitelisted realm roles (`db-writer`, `db-reader`) become Postgres role names (`writer`, `reader`), and the resulting `SET ROLE` decides what each user can do at the database. A user granted BOTH realm roles picks one at query time.
+
+## Architecture
+
+```
+┌──────────────────┐  1. browser OAuth   ┌──────────────────┐
+│ demo_client.py   │ ──────────────────► │ Keycloak         │
+│ (or Inspector,   │                     │ http://:18081    │
+│  Cursor, Claude) │  2. Streamable HTTP │ realm: yb-mcp-map│
+│                  │ ◄──── bearer ─────► │ realm roles:     │
+│                  │                     │  db-writer       │
+│                  │                     │  db-reader       │
+└──────────────────┘                     └──────────────────┘
+         │
+         ▼
+┌────────────────────────────────────────────────┐    ┌──────────────────┐
+│ yugabytedb-mcp-server                          │    │ YugabyteDB       │
+│ http://:8000  transport=http                   │    │                  │
+│ MCP_AUTH_PROVIDER=oidc                         │────►│  role: writer   │
+│ YB_MCP_IDENTITY_CLAIM=realm_access.roles       │ SQL │  role: reader   │
+│ YB_MCP_IDENTITY_MAP=./ident.conf               │+SET │  GRANTs decide  │
+│ YB_MCP_IDENTITY_MAP_NAME=default               │ROLE │  who can write  │
+└────────────────────────────────────────────────┘    └──────────────────┘
+```
+
+## Prerequisites
+
+- **Docker** (Engine ≥ 20.x) — to run Keycloak
+- **`uv`** — to run the MCP server (`brew install uv`, `pip install uv`, or [docs.astral.sh/uv](https://docs.astral.sh/uv/))
+- A reachable **YugabyteDB** instance — `yugabyted start` locally is fine; PostgreSQL works too
+- 15–20 minutes
+
+If you already ran the sibling [`examples/oidc-auth/`](../oidc-auth/README.md) tutorial, you can skip Step 2 (Postgres seed) — the roles / table / grants are identical.
+
+## Step 1 — Start Keycloak
+
+From this directory:
+
+```bash
+docker compose up -d
+```
+
+Wait ~20 seconds for Keycloak to boot and import the realm. Verify:
+
+```bash
+curl -fs http://localhost:18081/realms/yb-mcp-map/.well-known/openid-configuration | head -c 200
+```
+
+What just happened:
+- Keycloak 26 booted in dev mode on port `18081` (the sibling tutorial uses `18080` — both can coexist)
+- The `yb-mcp-map` realm was imported from `keycloak/realm-export.json`
+- A confidential client `yb-mcp-server` was registered with secret `tutorial-secret-not-for-prod`
+- Two realm roles were created — `db-writer`, `db-reader`
+- **Three** test users were created:
+
+  | Email | Password | Realm roles granted |
+  |---|---|---|
+  | `writer-only@yugabyte.com` | `Writer123` | `db-writer` |
+  | `reader-only@yugabyte.com` | `Reader123` | `db-reader` |
+  | `dual-role@yugabyte.com`   | `Dual123`   | `db-writer` AND `db-reader` |
+
+Every user also carries three Keycloak boilerplate roles — `offline_access`, `default-roles-yb-mcp-map`, `uma_authorization`. This is what the map file's allowlist is for — none of those boilerplate roles reach Postgres.
+
+The realm's audience mapper also stamps `aud: yb-mcp-server` on every access token, so the MCP server's audience validation (v2) accepts them.
+
+### View the realm in the admin console (optional)
+
+Open http://localhost:18081, sign in as `admin` / `admin`, and navigate to **Realm settings → yb-mcp-map**. Under **Realm roles** you'll see `db-writer` / `db-reader`. Under **Users**, each of the three demo users has role assignments visible on the **Role mapping** tab.
+
+## Step 2 — Seed the database
+
+If you already ran the sibling tutorial's seed, skip this — the roles are the same. Otherwise:
+
+```bash
+ysqlsh "$YUGABYTEDB_URL" -v yb_pool_user=yugabyte -f postgres-seed.sql
+```
+
+(Or `psql` if you're on stock PostgreSQL. Substitute `yugabyte` with whichever user appears in your `$YUGABYTEDB_URL`.)
+
+The seed creates two `NOLOGIN` Postgres roles (`writer`, `reader`), a demo `notes` table, appropriate GRANTs (writer can SELECT/INSERT/UPDATE/DELETE, reader can only SELECT), and grants the pool user membership in both — necessary for `SET ROLE` to succeed later.
+
+## Step 3 — Configure the MCP server
+
+From the repo root:
+
+```bash
+# Point to your database (same pool user you seeded above).
+export YUGABYTEDB_URL="host=localhost port=5433 user=yugabyte dbname=yugabyte"
+
+# Generic OIDC provider — Keycloak on 18081.
+export MCP_AUTH_PROVIDER=oidc
+export MCP_BASE_URL=http://localhost:8000
+export OIDC_CONFIG_URL=http://localhost:18081/realms/yb-mcp-map/.well-known/openid-configuration
+export OIDC_CLIENT_ID=yb-mcp-server
+export OIDC_CLIENT_SECRET=tutorial-secret-not-for-prod
+export OIDC_AUDIENCE=yb-mcp-server
+
+# The mapping bits — the whole point of this tutorial.
+export YB_MCP_IDENTITY_CLAIM=realm_access.roles
+export YB_MCP_IDENTITY_MAP="$(pwd)/examples/oidc-auth-mapping/ident.conf"
+export YB_MCP_IDENTITY_MAP_NAME=default
+
+# Write-query surface is off by default. Turn it on so the tutorial's
+# INSERT case works.
+export YB_MCP_ENABLE_WRITE_QUERY=true
+
+uv run yugabytedb-mcp --transport http
+```
+
+You should see the server log lines confirming both the OIDC provider and the identity map were parsed:
+
+```
+INFO   yugabytedb-mcp.auth  oidc provider configured  audience=yb-mcp-server
+INFO   yugabytedb-mcp.tools identity map loaded  path=/abs/path/ident.conf name=default entries=2
+INFO   yugabytedb-mcp.tools server listening       host=0.0.0.0 port=8000
+```
+
+If the identity-map line is missing, `YB_MCP_IDENTITY_MAP` didn't resolve — check the path.
+
+### Smoke-test the auth surface without a token
+
+```bash
+# /ping is unauthenticated → 200
+curl -si http://localhost:8000/ping | head -1
+
+# /mcp without a token → 401 + WWW-Authenticate header
+curl -si -X POST http://localhost:8000/mcp \
+     -H 'Content-Type: application/json' \
+     -H 'Accept: application/json, text/event-stream' \
+     -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"curl","version":"0"}}}' \
+     | head -5
+```
+
+## Step 4 — Run the one-command demo client
+
+From this directory:
+
+```bash
+uv run demo_client.py
+```
+
+The browser opens Keycloak's sign-in page. Pick a user:
+
+- `writer-only@yugabyte.com / Writer123` — single realm role, no `requested_role` needed
+- `reader-only@yugabyte.com / Reader123` — single realm role, no `requested_role` needed
+- `dual-role@yugabyte.com / Dual123` — two realm roles; the script passes `requested_role="writer"` by default
+
+The script prints the decoded token's `realm_access.roles`, what the server-side map will translate them to, whether `requested_role` will be sent, and then runs three tool calls: `current_user`, `SELECT`, `INSERT`.
+
+### Expected output — signed in as `writer-only`
+
+```
+==> Signed in as writer-only@yugabyte.com
+    JWT realm_access.roles: ['offline_access', 'default-roles-yb-mcp-map',
+                             'uma_authorization', 'db-writer']
+    Server-side mapped candidates: ['writer']
+
+==> Connected to MCP server. Tools: run_read_only_query, run_write_query, summarize_database
+
+--- 1. Confirm effective database role ---
+{
+  "columns": ["current_user", "session_user", "effective_role"],
+  "rows": [["writer", "yugabyte", "writer"]]
+}
+
+--- 2. SELECT from notes ---
+{
+  "columns": ["id", "body"],
+  "rows": [[1, "hello, world (seeded)"], [2, "reader can see this"]]
+}
+
+--- 3. INSERT into notes as writer ---
+{ "rows_affected": 1 }
+```
+
+The three Keycloak boilerplate roles (`offline_access`, `default-roles-yb-mcp-map`, `uma_authorization`) were in the token but never touched the database — the map dropped them.
+
+### Expected output — signed in as `reader-only`
+
+```
+==> Signed in as reader-only@yugabyte.com
+    JWT realm_access.roles: ['offline_access', 'default-roles-yb-mcp-map',
+                             'uma_authorization', 'db-reader']
+    Server-side mapped candidates: ['reader']
+
+--- 1. Confirm effective database role ---
+{
+  "columns": ["current_user", "session_user", "effective_role"],
+  "rows": [["reader", "yugabyte", "reader"]]
+}
+
+--- 3. INSERT into notes as reader ---
+Error: permission denied for table notes
+```
+
+Same MCP server, same pool connection, same tool — the database refused because the token drove `SET ROLE reader` for this request.
+
+### Expected output — signed in as `dual-role`
+
+```
+==> Signed in as dual-role@yugabyte.com
+    JWT realm_access.roles: ['offline_access', 'default-roles-yb-mcp-map',
+                             'uma_authorization', 'db-writer', 'db-reader']
+    Server-side mapped candidates: ['writer', 'reader']
+    Two candidates → passing requested_role='writer' on each tool call.
+
+--- 1. Confirm effective database role ---
+{
+  "columns": ["current_user", "session_user", "effective_role"],
+  "rows": [["writer", "yugabyte", "writer"]]
+}
+
+--- 3. INSERT into notes as writer ---
+{ "rows_affected": 1 }
+```
+
+Re-run with `DEMO_REQUESTED_ROLE=reader uv run demo_client.py` — the same user's token now drives `SET ROLE reader` and the INSERT is denied.
+
+### Try each user
+
+The OAuth request includes `prompt=login`, so Keycloak always shows the sign-in form and ignores cached sessions. Just re-run the script to switch users.
+
+## Step 5 — (Optional) Same thing via curl
+
+Same idea as the sibling tutorial. Fetch tokens directly via the resource-owner-password grant (dev-only), then hit `/mcp` with the bearer.
+
+```bash
+# --- Grab tokens ---
+# Note: the yb-mcp-audience client scope is a *default* scope on the client,
+# so Keycloak applies it automatically. Requesting it explicitly via `scope=`
+# returns invalid_scope. Just ask for the standard OIDC scopes.
+DUAL=$(curl -sf -X POST http://localhost:18081/realms/yb-mcp-map/protocol/openid-connect/token \
+  -d grant_type=password -d client_id=yb-mcp-server \
+  -d client_secret=tutorial-secret-not-for-prod \
+  -d username=dual-role@yugabyte.com -d password=Dual123 | jq -r .access_token)
+
+# --- Peek at what the server will see ---
+echo "$DUAL" | cut -d. -f2 | tr '_-' '/+' | base64 -d 2>/dev/null | jq '.realm_access'
+# {
+#   "roles": [
+#     "offline_access", "default-roles-yb-mcp-map", "uma_authorization",
+#     "db-writer", "db-reader"
+#   ]
+# }
+
+# --- The ambiguous case: two mapped candidates + explicit requested_role ---
+curl -s -X POST http://localhost:8000/mcp \
+  -H "Authorization: Bearer $DUAL" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{
+       "name":"run_read_only_query",
+       "arguments":{
+         "query":"SELECT current_setting('\''role'\'') AS effective_role",
+         "requested_role":"reader"
+       }}}'
+```
+
+Change `requested_role` between calls and watch the `effective_role` flip without touching Keycloak or the database.
+
+## How it works under the hood
+
+The mapping pipeline (documented in [`OIDC.md`](../../OIDC.md#the-mapping-flow)):
+
+```
+JWT access token
+  │  aud=yb-mcp-server (audience validated against OIDC_AUDIENCE)
+  │  realm_access.roles = ["offline_access","default-roles-yb-mcp-map",
+  │                        "uma_authorization","db-writer","db-reader"]
+  │
+  ├─ (2) Extract identity claim by dotted path
+  │       YB_MCP_IDENTITY_CLAIM=realm_access.roles
+  │       → walks claims["realm_access"]["roles"]
+  │
+  ├─ (3) Normalize to list of raw strings
+  │       → ["offline_access", "default-roles-yb-mcp-map",
+  │          "uma_authorization", "db-writer", "db-reader"]
+  │
+  ├─ (4) Apply identity map (ident.conf)
+  │       offline_access              → NO MATCH → dropped
+  │       default-roles-yb-mcp-map    → NO MATCH → dropped
+  │       uma_authorization           → NO MATCH → dropped
+  │       db-writer                   → writer
+  │       db-reader                   → reader
+  │       candidates = ["writer","reader"]
+  │
+  ├─ (5) Pick one candidate
+  │       requested_role="writer" passed by the client
+  │       clamped against candidates → allowed
+  │
+  └─ (6) SET ROLE writer (psycopg.sql.Identifier — always quoted)
+```
+
+**Fail-closed guarantees exercised by this setup:**
+
+| Scenario | Outcome |
+|---|---|
+| Token has no `realm_access.roles` at all | `IdentityError` — no fallback to pool credentials |
+| Token has only boilerplate realm roles | `IdentityError` — no candidate remains after the map |
+| Ambiguous candidates, `requested_role` omitted | `IdentityError` — server refuses to pick arbitrarily |
+| `requested_role` names a role NOT in the mapped candidates | `IdentityError` — clamp fails |
+| Map file has an invalid `\N` backreference | Server refuses to start (fail-closed at load) |
+
+The map IS the allowlist — every additional realm role on the token is either mapped explicitly or silently dropped.
+
+## Adapting to a different OIDC provider
+
+Same steps for Auth0, Okta, Azure AD, or any RFC 6749 / OIDC 1.0 provider — swap:
+
+- `OIDC_CONFIG_URL` — provider's discovery document
+- `OIDC_CLIENT_ID` / `OIDC_CLIENT_SECRET` — client registered with the provider
+- `OIDC_AUDIENCE` — expected `aud` claim (often the client id itself)
+- `YB_MCP_IDENTITY_CLAIM` — path to the roles/groups list in the provider's tokens (see [OIDC.md's Worked examples](../../OIDC.md#worked-examples) for provider-specific claim paths)
+- `YB_MCP_IDENTITY_MAP` — an ident.conf whose left column matches whatever the IdP emits (raw group names, Azure GUIDs via regex, etc.)
+
+The pipeline downstream of extraction is identical regardless of provider.
+
+## Teardown
+
+```bash
+docker compose down -v     # nukes Keycloak state
+```
+
+Postgres roles / tables persist — drop them explicitly if you want to reset:
+
+```sql
+DROP TABLE IF EXISTS notes;
+DROP ROLE  IF EXISTS writer;
+DROP ROLE  IF EXISTS reader;
+```

--- a/examples/oidc-auth-mapping/demo_client.py
+++ b/examples/oidc-auth-mapping/demo_client.py
@@ -61,7 +61,7 @@ import webbrowser
 
 import httpx
 from mcp import ClientSession
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
 
 KEYCLOAK_AUTHORIZE_URL = (
     "http://localhost:18081/realms/yb-mcp-map/protocol/openid-connect/auth"
@@ -213,57 +213,65 @@ async def run_mcp(token: str, claims: dict) -> None:
     if requested_role is not None:
         tool_args_common["requested_role"] = requested_role
 
+    # The new `streamable_http_client` API takes an `httpx.AsyncClient`
+    # for header / auth configuration rather than accepting `headers=` as
+    # a kwarg (the old `streamablehttp_client` shape was deprecated in
+    # mcp SDK v1.19+ in favor of this).
     headers = {"Authorization": f"Bearer {token}"}
-    async with streamablehttp_client(MCP_URL, headers=headers) as (
-        read_stream,
-        write_stream,
-        _,
-    ):
-        async with ClientSession(read_stream, write_stream) as session:
-            await session.initialize()
-            tools = await session.list_tools()
-            tool_names = sorted(t.name for t in tools.tools)
-            print(f"==> Connected to MCP server. Tools: {', '.join(tool_names)}\n")
+    async with httpx.AsyncClient(headers=headers) as http_client:
+        # mcp>=2.0 yields (read_stream, write_stream); v1.x yielded a third
+        # `get_session_id` callback. `*_` accepts both so the tutorial works
+        # against whichever version uv resolves.
+        async with streamable_http_client(MCP_URL, http_client=http_client) as (
+            read_stream,
+            write_stream,
+            *_,
+        ):
+            async with ClientSession(read_stream, write_stream) as session:
+                await session.initialize()
+                tools = await session.list_tools()
+                tool_names = sorted(t.name for t in tools.tools)
+                print(f"==> Connected to MCP server. Tools: {', '.join(tool_names)}\n")
 
-            print("--- 1. Confirm effective database role ---")
-            render(
-                await session.call_tool(
-                    "run_read_only_query",
-                    {
-                        "query": (
-                            "SELECT current_user, session_user, "
-                            "current_setting('role') AS effective_role"
-                        ),
-                        **tool_args_common,
-                    },
+                print("--- 1. Confirm effective database role ---")
+                render(
+                    await session.call_tool(
+                        "run_read_only_query",
+                        {
+                            "query": (
+                                "SELECT current_user, session_user, "
+                                "current_setting('role') AS effective_role"
+                            ),
+                            **tool_args_common,
+                        },
+                    )
                 )
-            )
 
-            print("\n--- 2. SELECT from notes ---")
-            render(
-                await session.call_tool(
-                    "run_read_only_query",
-                    {
-                        "query": "SELECT id, body FROM notes ORDER BY id",
-                        **tool_args_common,
-                    },
+                print("\n--- 2. SELECT from notes ---")
+                render(
+                    await session.call_tool(
+                        "run_read_only_query",
+                        {
+                            "query": "SELECT id, body FROM notes ORDER BY id",
+                            **tool_args_common,
+                        },
+                    )
                 )
-            )
 
-            picked = requested_role or (mapped[0] if mapped else "<none>")
-            print(f"\n--- 3. INSERT into notes as {picked} ---")
-            render(
-                await session.call_tool(
-                    "run_write_query",
-                    {
-                        "query": (
-                            "INSERT INTO notes (body) VALUES "
-                            f"('hello from {picked} (mapping demo)')"
-                        ),
-                        **tool_args_common,
-                    },
+                picked = requested_role or (mapped[0] if mapped else "<none>")
+                print(f"\n--- 3. INSERT into notes as {picked} ---")
+                render(
+                    await session.call_tool(
+                        "run_write_query",
+                        {
+                            "query": (
+                                "INSERT INTO notes (body) VALUES "
+                                f"('hello from {picked} (mapping demo)')"
+                            ),
+                            **tool_args_common,
+                        },
+                    )
                 )
-            )
 
 
 def main() -> None:

--- a/examples/oidc-auth-mapping/demo_client.py
+++ b/examples/oidc-auth-mapping/demo_client.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#   "httpx",
+#   "mcp>=1.2",
+# ]
+# ///
+"""One-command MCP client for the identity-mapping tutorial.
+
+Companion to examples/oidc-auth/demo_client.py — same auth-code + PKCE
+flow, but drives the v2 identity-mapping path:
+
+  * JWT claim = realm_access.roles  (list-valued, nested)
+  * identity map replaces the strip_domain transform
+  * for the dual-role user, the tool call passes requested_role so the
+    server clamps the ambiguous candidate list to a single pick
+
+Run:
+
+    uv run demo_client.py
+
+Signs you in to Keycloak on 18081 and hits three MCP tools. Try each
+user in turn (re-run the script — prompt=login skips cached sessions):
+
+    writer-only@yugabyte.com / Writer123
+        realm_access.roles = ["db-writer", "default-roles-yb-mcp-map"]
+        map: db-writer → writer (boilerplate dropped) → SET ROLE writer
+        INSERT succeeds.
+
+    reader-only@yugabyte.com / Reader123
+        realm_access.roles = ["db-reader", "default-roles-yb-mcp-map"]
+        map: db-reader → reader → SET ROLE reader
+        INSERT is denied at the DB.
+
+    dual-role@yugabyte.com / Dual123
+        realm_access.roles = ["db-writer", "db-reader",
+                              "default-roles-yb-mcp-map"]
+        map: both → ["writer","reader"] — TWO candidates.
+        The script picks "writer" via requested_role. INSERT succeeds.
+        (Re-run with DEMO_REQUESTED_ROLE=reader to switch to reader.)
+
+Prerequisites: docker compose up in this directory, seed script run
+against your YB, MCP server running with YB_MCP_IDENTITY_CLAIM=
+realm_access.roles + YB_MCP_IDENTITY_MAP=<path to ident.conf>.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import http.server
+import json
+import os
+import secrets
+import sys
+import threading
+import urllib.parse
+import webbrowser
+
+import httpx
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+
+KEYCLOAK_AUTHORIZE_URL = (
+    "http://localhost:18081/realms/yb-mcp-map/protocol/openid-connect/auth"
+)
+KEYCLOAK_TOKEN_URL = (
+    "http://localhost:18081/realms/yb-mcp-map/protocol/openid-connect/token"
+)
+CLIENT_ID = "yb-mcp-server"
+CLIENT_SECRET = "tutorial-secret-not-for-prod"
+MCP_URL = "http://localhost:8000/mcp"
+CALLBACK_HOST = "127.0.0.1"
+# Distinct from oidc-auth/demo_client.py's 9876 so both scripts can run
+# concurrently without fighting over the loopback port.
+CALLBACK_PORT = 9877
+REDIRECT_URI = f"http://localhost:{CALLBACK_PORT}/callback"
+
+_received: dict[str, str | None] = {"code": None, "state": None, "error": None}
+
+
+class _CallbackHandler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):  # noqa: N802
+        params = urllib.parse.parse_qs(urllib.parse.urlparse(self.path).query)
+        _received["code"] = (params.get("code") or [None])[0]
+        _received["state"] = (params.get("state") or [None])[0]
+        _received["error"] = (params.get("error") or [None])[0]
+        body = (
+            "<html><body style='font-family: sans-serif; max-width: 480px;"
+            " margin: 4em auto; color: #202124;'>"
+            "<h2>Signed in.</h2>"
+            "<p>You can close this tab and return to the terminal.</p>"
+            "</body></html>"
+        )
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.end_headers()
+        self.wfile.write(body.encode("utf-8"))
+
+    def log_message(self, *args, **kwargs):  # silence default access log
+        pass
+
+
+def authorization_code_flow() -> str:
+    """Drive the auth-code-with-PKCE flow and return the access token."""
+    code_verifier = secrets.token_urlsafe(64)
+    code_challenge = (
+        base64.urlsafe_b64encode(hashlib.sha256(code_verifier.encode()).digest())
+        .rstrip(b"=")
+        .decode("ascii")
+    )
+    state = secrets.token_urlsafe(16)
+
+    server = http.server.HTTPServer(
+        (CALLBACK_HOST, CALLBACK_PORT), _CallbackHandler
+    )
+    listener = threading.Thread(target=server.handle_request, daemon=True)
+    listener.start()
+
+    params = {
+        "client_id": CLIENT_ID,
+        "response_type": "code",
+        "redirect_uri": REDIRECT_URI,
+        "scope": "openid email profile",
+        "state": state,
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+        "prompt": "login",
+    }
+    authorize_url = f"{KEYCLOAK_AUTHORIZE_URL}?{urllib.parse.urlencode(params)}"
+
+    print("==> Opening browser for Keycloak sign-in...")
+    print(f"    (if your browser does not open, visit:\n     {authorize_url}\n    )")
+    webbrowser.open(authorize_url)
+
+    listener.join(timeout=300)
+    server.server_close()
+
+    if _received["error"]:
+        sys.exit(f"Keycloak returned an error: {_received['error']}")
+    if not _received["code"]:
+        sys.exit("Timed out waiting for the OAuth callback.")
+    if _received["state"] != state:
+        sys.exit("State mismatch — possible CSRF.")
+
+    with httpx.Client(timeout=10) as http_:
+        r = http_.post(
+            KEYCLOAK_TOKEN_URL,
+            data={
+                "grant_type": "authorization_code",
+                "code": _received["code"],
+                "redirect_uri": REDIRECT_URI,
+                "client_id": CLIENT_ID,
+                "client_secret": CLIENT_SECRET,
+                "code_verifier": code_verifier,
+            },
+        )
+    if r.status_code != 200:
+        sys.exit(f"Token exchange failed ({r.status_code}): {r.text}")
+    return r.json()["access_token"]
+
+
+def decode_claims(access_token: str) -> dict:
+    """Best-effort decode of the JWT payload without signature check."""
+    payload_b64 = access_token.split(".")[1]
+    payload_b64 += "=" * (-len(payload_b64) % 4)
+    return json.loads(base64.urlsafe_b64decode(payload_b64))
+
+
+def summarize_identity(claims: dict) -> tuple[str, list[str]]:
+    """Return (email, list-of-realm-roles) so the caller can print a preview."""
+    email = claims.get("email") or claims.get("preferred_username") or "<unknown>"
+    realm_access = claims.get("realm_access") or {}
+    roles = list(realm_access.get("roles") or [])
+    return email, roles
+
+
+def render(result) -> None:
+    for block in result.content:
+        text = getattr(block, "text", None)
+        if text is None:
+            continue
+        try:
+            print(json.dumps(json.loads(text), indent=2))
+        except (json.JSONDecodeError, TypeError):
+            print(text)
+
+
+async def run_mcp(token: str, claims: dict) -> None:
+    email, realm_roles = summarize_identity(claims)
+    print(f"==> Signed in as {email}")
+    print(f"    JWT realm_access.roles: {realm_roles}")
+
+    # Figure out which mapped candidates the server will see. This mirrors
+    # ident.conf so what the tutorial prints matches what the server does.
+    map_from_realm = {"db-writer": "writer", "db-reader": "reader"}
+    mapped = [map_from_realm[r] for r in realm_roles if r in map_from_realm]
+    print(f"    Server-side mapped candidates: {mapped}")
+
+    ambiguous = len(mapped) > 1
+    requested_role: str | None = None
+    if ambiguous:
+        requested_role = os.environ.get("DEMO_REQUESTED_ROLE", "writer")
+        print(
+            f"    Two candidates → passing requested_role={requested_role!r}"
+            " on each tool call."
+        )
+    print()
+
+    tool_args_common: dict[str, str] = {}
+    if requested_role is not None:
+        tool_args_common["requested_role"] = requested_role
+
+    headers = {"Authorization": f"Bearer {token}"}
+    async with streamablehttp_client(MCP_URL, headers=headers) as (
+        read_stream,
+        write_stream,
+        _,
+    ):
+        async with ClientSession(read_stream, write_stream) as session:
+            await session.initialize()
+            tools = await session.list_tools()
+            tool_names = sorted(t.name for t in tools.tools)
+            print(f"==> Connected to MCP server. Tools: {', '.join(tool_names)}\n")
+
+            print("--- 1. Confirm effective database role ---")
+            render(
+                await session.call_tool(
+                    "run_read_only_query",
+                    {
+                        "query": (
+                            "SELECT current_user, session_user, "
+                            "current_setting('role') AS effective_role"
+                        ),
+                        **tool_args_common,
+                    },
+                )
+            )
+
+            print("\n--- 2. SELECT from notes ---")
+            render(
+                await session.call_tool(
+                    "run_read_only_query",
+                    {
+                        "query": "SELECT id, body FROM notes ORDER BY id",
+                        **tool_args_common,
+                    },
+                )
+            )
+
+            picked = requested_role or (mapped[0] if mapped else "<none>")
+            print(f"\n--- 3. INSERT into notes as {picked} ---")
+            render(
+                await session.call_tool(
+                    "run_write_query",
+                    {
+                        "query": (
+                            "INSERT INTO notes (body) VALUES "
+                            f"('hello from {picked} (mapping demo)')"
+                        ),
+                        **tool_args_common,
+                    },
+                )
+            )
+
+
+def main() -> None:
+    token = authorization_code_flow()
+    claims = decode_claims(token)
+    asyncio.run(run_mcp(token, claims))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/oidc-auth-mapping/docker-compose.yaml
+++ b/examples/oidc-auth-mapping/docker-compose.yaml
@@ -38,8 +38,15 @@ services:
     command:
       - start-dev
       - --import-realm
+    # No curl/wget in the Keycloak image, so probe via a bash /dev/tcp
+    # HTTP/1.1 request. HTTP/1.0 without a Host header 500s on modern
+    # Keycloak, so we send Host: localhost + Connection: close.
     healthcheck:
-      test: ["CMD-SHELL", "exec 3<>/dev/tcp/127.0.0.1/8080 && echo -e 'GET /realms/yb-mcp-map/.well-known/openid-configuration HTTP/1.0\\r\\n\\r\\n' >&3 && head -1 <&3 | grep -q 200"]
+      test:
+        - CMD
+        - bash
+        - -c
+        - "exec 3<>/dev/tcp/127.0.0.1/8080 && printf 'GET /realms/yb-mcp-map/.well-known/openid-configuration HTTP/1.1\\r\\nHost: localhost\\r\\nConnection: close\\r\\n\\r\\n' >&3 && head -1 <&3 | grep -q 200"
       interval: 5s
       timeout: 3s
       retries: 30

--- a/examples/oidc-auth-mapping/docker-compose.yaml
+++ b/examples/oidc-auth-mapping/docker-compose.yaml
@@ -1,0 +1,45 @@
+# Local Keycloak instance for the identity-mapping tutorial.
+#
+# Sits ALONGSIDE examples/oidc-auth/ — different port (18081 vs 18080),
+# different realm (yb-mcp-map vs yb-mcp), so both examples can run at the
+# same time. This one demonstrates the v2 additions:
+#
+#   * list-valued claim (realm_access.roles)
+#   * dotted-path claim extraction (realm_access.roles walks two levels)
+#   * identity map file (whitelists meaningful realm roles, drops Keycloak
+#     boilerplate like offline_access / default-roles-yb-mcp-map)
+#   * `requested_role` handling for the dual-role user
+#   * audience validation via an OIDC audience mapper on the access token
+#
+# The realm ships three users:
+#
+#   writer-only@yugabyte.com  → realm role db-writer
+#   reader-only@yugabyte.com  → realm role db-reader
+#   dual-role@yugabyte.com    → both db-writer AND db-reader
+#
+# Admin console: http://localhost:18081  (admin / admin)
+# Realm endpoint: http://localhost:18081/realms/yb-mcp-map/.well-known/openid-configuration
+#
+# Start with:    docker compose up -d
+# Stop with:     docker compose down
+# Reset state:   docker compose down -v
+
+services:
+  keycloak:
+    image: quay.io/keycloak/keycloak:26.0
+    container_name: yb-mcp-keycloak-map
+    environment:
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
+    ports:
+      - "18081:8080"
+    volumes:
+      - ./keycloak:/opt/keycloak/data/import:ro
+    command:
+      - start-dev
+      - --import-realm
+    healthcheck:
+      test: ["CMD-SHELL", "exec 3<>/dev/tcp/127.0.0.1/8080 && echo -e 'GET /realms/yb-mcp-map/.well-known/openid-configuration HTTP/1.0\\r\\n\\r\\n' >&3 && head -1 <&3 | grep -q 200"]
+      interval: 5s
+      timeout: 3s
+      retries: 30

--- a/examples/oidc-auth-mapping/ident.conf
+++ b/examples/oidc-auth-mapping/ident.conf
@@ -1,0 +1,13 @@
+# Identity map — pg_ident.conf-style. Points YB_MCP_IDENTITY_MAP at this file.
+#
+# Format per line:
+#   <map_name>  <realm_role_name_from_JWT>  <postgres_role_to_SET_ROLE_into>
+#
+# Blank lines and comments are ignored. This is the allowlist: any realm role
+# not listed here is dropped, not fallen through. Keycloak boilerplate roles
+# (offline_access, default-roles-yb-mcp-map, uma_authorization) come through
+# on every token; leaving them out is what excludes them from the DB grant
+# path.
+
+default   db-writer   writer
+default   db-reader   reader

--- a/examples/oidc-auth-mapping/keycloak/realm-export.json
+++ b/examples/oidc-auth-mapping/keycloak/realm-export.json
@@ -71,6 +71,33 @@
           }
         }
       ]
+    },
+    {
+      "name": "openid",
+      "description": "OIDC built-in scope 'openid'",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "false"
+      }
+    },
+    {
+      "name": "email",
+      "description": "OIDC built-in scope 'email'",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true"
+      }
+    },
+    {
+      "name": "profile",
+      "description": "OIDC built-in scope 'profile'",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true"
+      }
     }
   ],
   "clients": [
@@ -113,7 +140,11 @@
       "enabled": true,
       "emailVerified": true,
       "credentials": [
-        { "type": "password", "value": "Writer123", "temporary": false }
+        {
+          "type": "password",
+          "value": "Writer123",
+          "temporary": false
+        }
       ],
       "realmRoles": [
         "db-writer",
@@ -128,7 +159,11 @@
       "enabled": true,
       "emailVerified": true,
       "credentials": [
-        { "type": "password", "value": "Reader123", "temporary": false }
+        {
+          "type": "password",
+          "value": "Reader123",
+          "temporary": false
+        }
       ],
       "realmRoles": [
         "db-reader",
@@ -143,7 +178,11 @@
       "enabled": true,
       "emailVerified": true,
       "credentials": [
-        { "type": "password", "value": "Dual123", "temporary": false }
+        {
+          "type": "password",
+          "value": "Dual123",
+          "temporary": false
+        }
       ],
       "realmRoles": [
         "db-writer",

--- a/examples/oidc-auth-mapping/keycloak/realm-export.json
+++ b/examples/oidc-auth-mapping/keycloak/realm-export.json
@@ -1,0 +1,155 @@
+{
+  "realm": "yb-mcp-map",
+  "enabled": true,
+  "sslRequired": "none",
+  "registrationAllowed": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": false,
+  "editUsernameAllowed": false,
+  "bruteForceProtected": false,
+  "accessTokenLifespan": 3600,
+  "roles": {
+    "realm": [
+      {
+        "name": "db-writer",
+        "description": "Grants write access on the demo notes table."
+      },
+      {
+        "name": "db-reader",
+        "description": "Grants read-only access on the demo notes table."
+      }
+    ]
+  },
+  "clientScopes": [
+    {
+      "name": "yb-mcp-audience",
+      "description": "Adds aud, email, and realm_access.roles claims to access tokens.",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "name": "yb-mcp-server-aud",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.client.audience": "yb-mcp-server",
+            "id.token.claim": "false",
+            "access.token.claim": "true"
+          }
+        },
+        {
+          "name": "email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "email",
+            "claim.name": "email",
+            "jsonType.label": "String",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "name": "realm-roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.name": "realm_access.roles",
+            "jsonType.label": "String",
+            "multivalued": "true",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "false"
+          }
+        }
+      ]
+    }
+  ],
+  "clients": [
+    {
+      "clientId": "yb-mcp-server",
+      "name": "YugabyteDB MCP Server (mapping tutorial)",
+      "description": "Confidential OAuth client for the mapping-tutorial realm. Issues access tokens carrying realm_access.roles for the three demo users; the MCP server extracts that list, applies the map file, and clamps to the picked role.",
+      "enabled": true,
+      "publicClient": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "tutorial-secret-not-for-prod",
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "redirectUris": [
+        "http://localhost:8000/auth/callback",
+        "http://localhost:8000/*",
+        "http://localhost:9877/callback"
+      ],
+      "webOrigins": [
+        "http://localhost:8000"
+      ],
+      "attributes": {
+        "pkce.code.challenge.method": "S256"
+      },
+      "defaultClientScopes": [
+        "openid",
+        "email",
+        "profile",
+        "yb-mcp-audience"
+      ]
+    }
+  ],
+  "users": [
+    {
+      "username": "writer-only",
+      "email": "writer-only@yugabyte.com",
+      "firstName": "Writer",
+      "lastName": "Only",
+      "enabled": true,
+      "emailVerified": true,
+      "credentials": [
+        { "type": "password", "value": "Writer123", "temporary": false }
+      ],
+      "realmRoles": [
+        "db-writer",
+        "default-roles-yb-mcp-map"
+      ]
+    },
+    {
+      "username": "reader-only",
+      "email": "reader-only@yugabyte.com",
+      "firstName": "Reader",
+      "lastName": "Only",
+      "enabled": true,
+      "emailVerified": true,
+      "credentials": [
+        { "type": "password", "value": "Reader123", "temporary": false }
+      ],
+      "realmRoles": [
+        "db-reader",
+        "default-roles-yb-mcp-map"
+      ]
+    },
+    {
+      "username": "dual-role",
+      "email": "dual-role@yugabyte.com",
+      "firstName": "Dual",
+      "lastName": "Role",
+      "enabled": true,
+      "emailVerified": true,
+      "credentials": [
+        { "type": "password", "value": "Dual123", "temporary": false }
+      ],
+      "realmRoles": [
+        "db-writer",
+        "db-reader",
+        "default-roles-yb-mcp-map"
+      ]
+    }
+  ]
+}

--- a/examples/oidc-auth-mapping/postgres-seed.sql
+++ b/examples/oidc-auth-mapping/postgres-seed.sql
@@ -1,0 +1,83 @@
+-- examples/oidc-auth-mapping/postgres-seed.sql
+--
+-- Seed for the identity-mapping tutorial. Same two Postgres roles as the
+-- companion examples/oidc-auth/ tutorial (writer / reader), but where THIS
+-- tutorial differs is HOW the caller lands on them:
+--
+--   * examples/oidc-auth/ — email → strip_domain → role
+--       writer@yugabyte.com  → SET ROLE writer
+--       reader@yugabyte.com  → SET ROLE reader
+--
+--   * this tutorial — realm_access.roles → identity map → role
+--       token contains ["db-writer"]           → SET ROLE writer
+--       token contains ["db-reader"]           → SET ROLE reader
+--       token contains ["db-writer","db-reader"] + requested_role="writer"
+--                                              → SET ROLE writer
+--
+-- Same enforcement, different plumbing. Run alongside the existing tutorial:
+-- these are Postgres roles, not Keycloak roles — one seed serves both.
+--
+-- Usage:
+--   ysqlsh "$YUGABYTEDB_URL" -v yb_pool_user=yugabyte -f postgres-seed.sql
+
+\set ON_ERROR_STOP on
+
+-- 1. Roles. NOLOGIN — they exist only to be SET ROLE'd into.
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'writer') THEN
+        CREATE ROLE writer NOLOGIN;
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'reader') THEN
+        CREATE ROLE reader NOLOGIN;
+    END IF;
+END $$;
+
+-- 2. Demo table (idempotent — same schema as the sibling tutorial).
+CREATE TABLE IF NOT EXISTS notes (
+    id    SERIAL PRIMARY KEY,
+    body  TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+INSERT INTO notes (body)
+SELECT 'hello, world (seeded)'
+WHERE NOT EXISTS (SELECT 1 FROM notes);
+
+INSERT INTO notes (body)
+SELECT 'reader can see this'
+WHERE (SELECT COUNT(*) FROM notes) < 2;
+
+-- 3. GRANTs.
+GRANT SELECT ON notes TO reader;
+GRANT SELECT, INSERT, UPDATE, DELETE ON notes TO writer;
+GRANT USAGE, SELECT, UPDATE ON SEQUENCE notes_id_seq TO writer;
+
+-- 4. Pool-user membership. `SET ROLE reader` from the pool connection
+-- fails with "permission denied to set role" without this.
+GRANT writer TO :"yb_pool_user";
+GRANT reader TO :"yb_pool_user";
+
+-- 5. Sanity output so the reader can confirm the seed worked.
+\echo
+\echo '=== Roles ==='
+SELECT rolname FROM pg_roles WHERE rolname IN ('writer', 'reader') ORDER BY rolname;
+
+\echo
+\echo '=== GRANTs on notes ==='
+SELECT grantee, privilege_type
+FROM information_schema.table_privileges
+WHERE table_name = 'notes' AND grantee IN ('writer', 'reader')
+ORDER BY grantee, privilege_type;
+
+\echo
+\echo '=== Membership ==='
+SELECT r.rolname AS member, g.rolname AS in_group
+FROM pg_auth_members m
+JOIN pg_roles r ON r.oid = m.member
+JOIN pg_roles g ON g.oid = m.roleid
+WHERE g.rolname IN ('writer', 'reader')
+ORDER BY g.rolname, r.rolname;
+
+\echo
+\echo 'Seed complete.'

--- a/src/yugabytedb_mcp_server/auth.py
+++ b/src/yugabytedb_mcp_server/auth.py
@@ -96,19 +96,74 @@ def _create_cognito():
             return []
 
     class _CognitoJWTVerifier(JWTVerifier):
-        """JWTVerifier that additionally enforces ``token_use=access`` on
-        Cognito claims when configured. Off by default (backward compat);
-        opt-in via ``YB_MCP_REQUIRE_ACCESS_TOKEN=true``. See DB-22136."""
+        """JWTVerifier with two Cognito-specific overrides:
 
-        def __init__(self, *, require_access_token: bool, **kwargs):
-            super().__init__(**kwargs)
+        1. **Audience matches ``aud`` OR ``client_id``.** Cognito ID tokens
+           carry the app client identifier in the standard ``aud`` claim,
+           but **access tokens omit ``aud`` entirely** and put the identifier
+           in ``client_id`` instead
+           (https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-using-tokens-with-identity-providers.html).
+           FastMCP's stock ``JWTVerifier`` only checks ``aud``, so a
+           straight ``audience=client_id`` argument rejects every Cognito
+           access token with "audience mismatch (got None, expected …)".
+           We disable the parent's audience check (pass ``audience=None``)
+           and run our own check here that accepts either claim.
+
+        2. **``token_use=access`` enforcement** (opt-in via
+           ``YB_MCP_REQUIRE_ACCESS_TOKEN=true``, off by default for
+           backward compat). See DB-22136.
+        """
+
+        def __init__(
+            self,
+            *,
+            require_access_token: bool,
+            expected_audience: str,
+            **kwargs,
+        ):
+            # Disable the parent's aud check — see class docstring for why.
+            super().__init__(audience=None, **kwargs)
             self._require_access_token = require_access_token
+            self._expected_audience = expected_audience
+
+        def _audience_matches(self, claims: dict) -> bool:
+            """Accept a token if either ``aud`` or ``client_id`` names our
+            expected audience. Handles ``aud`` being a list per RFC 7519."""
+            expected = self._expected_audience
+            aud = claims.get("aud")
+            if aud is not None:
+                if isinstance(aud, list):
+                    if expected in aud:
+                        return True
+                elif aud == expected:
+                    return True
+            # Cognito access-token fallback.
+            if claims.get("client_id") == expected:
+                return True
+            return False
 
         async def verify_token(self, token: str):
             result = await super().verify_token(token)
             if result is None:
                 return None
-            token_use = (result.claims or {}).get("token_use")
+            claims = result.claims or {}
+
+            # Audience check (aud OR client_id) — before token_use so a
+            # wrong-audience token is rejected even in the default (non-strict)
+            # mode.
+            if not self._audience_matches(claims):
+                logger.warning(
+                    "Rejected Cognito token: audience mismatch. "
+                    "expected=%r, aud=%r, client_id=%r. "
+                    "Token was minted for a different app client than the one "
+                    "this MCP server is configured to accept (COGNITO_CLIENT_ID).",
+                    self._expected_audience,
+                    claims.get("aud"),
+                    claims.get("client_id"),
+                )
+                return None
+
+            token_use = claims.get("token_use")
             if self._require_access_token and token_use != "access":
                 logger.warning(
                     "Rejected Cognito token with token_use=%r "
@@ -163,11 +218,13 @@ def _create_cognito():
     require_access_token = _env_bool("YB_MCP_REQUIRE_ACCESS_TOKEN", default=False)
     raw_jwt_verifier = _CognitoJWTVerifier(
         require_access_token=require_access_token,
+        # DB-22136: block tokens minted for other app clients in the same
+        # user pool. Cognito ID tokens set `aud=client_id`; Cognito access
+        # tokens set `client_id` and omit `aud`. `_CognitoJWTVerifier`
+        # accepts either — see class docstring.
+        expected_audience=client_id,
         jwks_uri=str(proxy.oidc_config.jwks_uri),
         issuer=str(proxy.oidc_config.issuer),
-        # DB-22136: audience-check blocks tokens minted for other app clients
-        # in the same user pool. Cognito uses the app client_id as `aud`.
-        audience=client_id,
     )
 
     logger.info(

--- a/src/yugabytedb_mcp_server/auth.py
+++ b/src/yugabytedb_mcp_server/auth.py
@@ -51,7 +51,34 @@ def create_auth_provider(name: str | None):
         )
 
 
+def _env_bool(name: str, default: bool = False) -> bool:
+    """Parse a boolean env var. Accepts case-insensitive `true` as True;
+    anything else (including unset) is False. Matches the existing
+    `.lower() == "true"` idiom used elsewhere in server.py."""
+    return os.environ.get(name, "").lower() == "true"
+
+
 def _create_cognito():
+    """AWS Cognito auth provider.
+
+    Two DB-22136 fixes applied here:
+
+    1. **Audience validation (always on).** `JWTVerifier(audience=...)` is
+       initialized with the Cognito App-client ID — Cognito access tokens
+       carry `aud=<client_id>`, so a token minted for a different app client
+       in the same user pool is rejected. Blocks the "any token from this
+       pool works" gap.
+
+    2. **`token_use=access` enforcement (opt-in).** When
+       `YB_MCP_REQUIRE_ACCESS_TOKEN=true`, `_CognitoJWTVerifier` overrides
+       `verify_token` to reject decoded claims whose `token_use != "access"`.
+       Rejects ID tokens and refresh tokens presented as bearers. Off by
+       default because existing deployments with `YB_MCP_IDENTITY_CLAIM=email`
+       rely on ID tokens (email is not in the access token) — see
+       DB-22192. Migration path: switch `identity_claim` to a claim present
+       in access tokens (e.g. `cognito:groups`, `sub`), then flip this env
+       to `true`.
+    """
     from fastmcp.server.auth.oidc_proxy import OIDCProxy
     from fastmcp.server.auth.auth import MultiAuth
     from fastmcp.server.auth.providers.jwt import JWTVerifier
@@ -68,8 +95,44 @@ def _create_cognito():
         def _prepare_scopes_for_token_exchange(self, scopes: list[str]) -> list[str]:
             return []
 
+    class _CognitoJWTVerifier(JWTVerifier):
+        """JWTVerifier that additionally enforces ``token_use=access`` on
+        Cognito claims when configured. Off by default (backward compat);
+        opt-in via ``YB_MCP_REQUIRE_ACCESS_TOKEN=true``. See DB-22136."""
+
+        def __init__(self, *, require_access_token: bool, **kwargs):
+            super().__init__(**kwargs)
+            self._require_access_token = require_access_token
+
+        async def verify_token(self, token: str):
+            result = await super().verify_token(token)
+            if result is None:
+                return None
+            token_use = (result.claims or {}).get("token_use")
+            if self._require_access_token and token_use != "access":
+                logger.warning(
+                    "Rejected Cognito token with token_use=%r "
+                    "(YB_MCP_REQUIRE_ACCESS_TOKEN=true). Only access tokens "
+                    "are accepted at /mcp; present an access token instead "
+                    "of an ID or refresh token.",
+                    token_use,
+                )
+                return None
+            if not self._require_access_token and token_use == "id":
+                # Loud warning on the default path so operators see the
+                # gap in logs and can migrate to access-token-only.
+                logger.warning(
+                    "Accepted Cognito ID token (token_use=id). Consider "
+                    "switching to access tokens: change YB_MCP_IDENTITY_CLAIM "
+                    "to a claim present in access tokens (e.g. cognito:groups "
+                    "or sub) and set YB_MCP_REQUIRE_ACCESS_TOKEN=true. "
+                    "See OIDC.md for the migration path."
+                )
+            return result
+
     pool_id = os.environ["COGNITO_USER_POOL_ID"]
     region = os.environ["COGNITO_AWS_REGION"]
+    client_id = os.environ["COGNITO_CLIENT_ID"]
     logger.debug("Configuring Cognito provider (pool=%s, region=%s)", pool_id, region)
     config_url = (
         f"https://cognito-idp.{region}.amazonaws.com/{pool_id}/"
@@ -82,7 +145,7 @@ def _create_cognito():
 
     proxy = _CognitoProxy(
         config_url=config_url,
-        client_id=os.environ["COGNITO_CLIENT_ID"],
+        client_id=client_id,
         client_secret=os.environ["COGNITO_CLIENT_SECRET"],
         base_url=base_url,
         token_endpoint_auth_method="client_secret_basic",
@@ -97,18 +160,36 @@ def _create_cognito():
     if getattr(proxy, "_cimd_manager", None) is not None:
         proxy._cimd_manager.default_scope = scopes
 
-    raw_jwt_verifier = JWTVerifier(
+    require_access_token = _env_bool("YB_MCP_REQUIRE_ACCESS_TOKEN", default=False)
+    raw_jwt_verifier = _CognitoJWTVerifier(
+        require_access_token=require_access_token,
         jwks_uri=str(proxy.oidc_config.jwks_uri),
         issuer=str(proxy.oidc_config.issuer),
+        # DB-22136: audience-check blocks tokens minted for other app clients
+        # in the same user pool. Cognito uses the app client_id as `aud`.
+        audience=client_id,
     )
 
-    logger.info("Cognito auth provider created (pool=%s, region=%s)", pool_id, region)
+    logger.info(
+        "Cognito auth provider created (pool=%s, region=%s, "
+        "audience=%s, require_access_token=%s)",
+        pool_id, region, client_id, require_access_token,
+    )
     return MultiAuth(server=proxy, verifiers=[raw_jwt_verifier])
 
 
 def _create_oidc():
     """Generic OIDC provider. Untested — exercise at your own risk and please
-    report findings."""
+    report findings.
+
+    DB-22136 audience-validation fix: `OIDC_AUDIENCE` (already read for
+    `OIDCProxy`) is now also forwarded to `JWTVerifier`, so a token issued
+    to a different client of the same issuer is rejected at the verifier
+    layer. `token_use=access` enforcement is NOT applied here because
+    non-Cognito IdPs may not emit `token_use` (or use a different claim
+    name); operators of Cognito-specific setups should use the `cognito`
+    provider instead.
+    """
     from fastmcp.server.auth.oidc_proxy import OIDCProxy
     from fastmcp.server.auth.auth import MultiAuth
     from fastmcp.server.auth.providers.jwt import JWTVerifier
@@ -126,12 +207,26 @@ def _create_oidc():
         base_url=os.environ.get("MCP_BASE_URL", "http://localhost:8000"),
     )
 
+    if not audience:
+        logger.warning(
+            "OIDC provider configured without OIDC_AUDIENCE. Tokens will "
+            "only be checked for signature and issuer, not audience. Any "
+            "validly-signed token from the same issuer will be accepted. "
+            "Set OIDC_AUDIENCE to the client ID / resource identifier this "
+            "server expects."
+        )
+
     raw_jwt_verifier = JWTVerifier(
         jwks_uri=str(proxy.oidc_config.jwks_uri),
         issuer=str(proxy.oidc_config.issuer),
+        # DB-22136: forward the audience to the verifier when present.
+        audience=audience,
     )
 
-    logger.info("OIDC auth provider created (config_url=%s)", config_url)
+    logger.info(
+        "OIDC auth provider created (config_url=%s, audience=%s)",
+        config_url, audience or "<unset>",
+    )
     return MultiAuth(server=proxy, verifiers=[raw_jwt_verifier])
 
 

--- a/src/yugabytedb_mcp_server/auth.py
+++ b/src/yugabytedb_mcp_server/auth.py
@@ -52,10 +52,27 @@ def create_auth_provider(name: str | None):
 
 
 def _env_bool(name: str, default: bool = False) -> bool:
-    """Parse a boolean env var. Accepts case-insensitive `true` as True;
-    anything else (including unset) is False. Matches the existing
-    `.lower() == "true"` idiom used elsewhere in server.py."""
-    return os.environ.get(name, "").lower() == "true"
+    """Parse a boolean env var.
+
+    - Unset → ``default``.
+    - Case-insensitive ``true`` / ``1`` / ``yes`` / ``on`` → ``True``.
+    - Case-insensitive ``false`` / ``0`` / ``no`` / ``off`` / ``""`` → ``False``.
+    - Anything else → ``default`` (with a WARNING so an operator-visible
+      typo doesn't silently flip a security flag).
+    """
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    v = raw.strip().lower()
+    if v in ("true", "1", "yes", "on"):
+        return True
+    if v in ("false", "0", "no", "off", ""):
+        return False
+    logger.warning(
+        "%s=%r is not a recognized boolean; falling back to default=%s",
+        name, raw, default,
+    )
+    return default
 
 
 def _create_cognito():

--- a/src/yugabytedb_mcp_server/server.py
+++ b/src/yugabytedb_mcp_server/server.py
@@ -18,7 +18,12 @@ import boto3
 
 from .guardrails import GuardrailConfig
 from .auth import create_auth_provider, cognito_password_login, CognitoLoginError
-from .tools import summarize_database, run_read_only_query, run_write_query
+from .tools import (
+    summarize_database,
+    run_read_only_query,
+    run_write_query,
+    _load_identity_map,
+)
 
 logger = logging.getLogger("yugabytedb-mcp.server")
 
@@ -39,6 +44,8 @@ class ServerConfig:
     enable_write_query: bool
     identity_claim: str
     identity_transform: str
+    identity_map_path: str | None
+    identity_map_name: str
 
 
 def normalize_pem(pem: str) -> str:
@@ -135,12 +142,42 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[dict]:
         guardrail_config.require_where_on_update,
         guardrail_config.require_where_on_delete,
     )
+    # Load the identity map file (pg_ident.conf-style) if configured. Parsed
+    # once at startup; a malformed file raises ValueError which we let
+    # propagate — the server refuses to start rather than silently accepting
+    # a typo'd map that could widen access.
+    identity_map = None
+    if CONFIG.identity_map_path:
+        logger.info(
+            "Loading identity map from %s (map_name=%s)",
+            CONFIG.identity_map_path, CONFIG.identity_map_name,
+        )
+        identity_map = _load_identity_map(CONFIG.identity_map_path)
+        logger.info(
+            "Identity map loaded: %d entries (%d under map_name=%s)",
+            len(identity_map),
+            sum(1 for e in identity_map if e.name == CONFIG.identity_map_name),
+            CONFIG.identity_map_name,
+        )
+
     if CONFIG.auth_provider:
         logger.info(
-            "Per-user SET ROLE enabled (claim=%s, transform=%s). "
-            "The pool user must be a superuser or have membership in target roles.",
-            CONFIG.identity_claim, CONFIG.identity_transform,
+            "Per-user SET ROLE enabled (claim=%s, transform=%s, map=%s). "
+            "The pool user must have GRANT to the target roles it needs to "
+            "SET ROLE to; superuser works but is not required if an identity "
+            "map is set.",
+            CONFIG.identity_claim,
+            CONFIG.identity_transform,
+            CONFIG.identity_map_path or "<none>",
         )
+        if identity_map is None:
+            logger.warning(
+                "OIDC identity mapping has no map file configured "
+                "(YB_MCP_IDENTITY_MAP unset). The claim value is used as the "
+                "DB role name directly, which requires the pool user to be a "
+                "superuser or have GRANT on every possible role. Configure "
+                "YB_MCP_IDENTITY_MAP to constrain the set of reachable roles."
+            )
 
     try:
         yield {
@@ -148,6 +185,8 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[dict]:
             "guardrail_config": guardrail_config,
             "identity_claim": CONFIG.identity_claim,
             "identity_transform": CONFIG.identity_transform,
+            "identity_map": identity_map,
+            "identity_map_name": CONFIG.identity_map_name,
         }
     finally:
         logger.info("Closing database connections")
@@ -232,8 +271,24 @@ def parse_config() -> ServerConfig:
         default=os.environ.get("YB_MCP_IDENTITY_TRANSFORM", "none"),
         choices=["none", "strip_domain"],
         help="Transform applied to the identity claim before using as DB role: "
-             "'none' (use as-is) or 'strip_domain' (strip @... from email) "
-             "(env: YB_MCP_IDENTITY_TRANSFORM, default: none)",
+             "'none' (use as-is) or 'strip_domain' (strip @... from email). "
+             "Only applies when no identity map file is configured; the map "
+             "path replaces this. (env: YB_MCP_IDENTITY_TRANSFORM, default: none)",
+    )
+    parser.add_argument(
+        "--identity-map",
+        default=os.environ.get("YB_MCP_IDENTITY_MAP"),
+        help="Path to a pg_ident.conf-style identity map file. Each line is "
+             "'<map_name> <system_value> <db_role>' — system_value may be a "
+             "literal string or /regex/ (leading slash triggers regex; role "
+             "may reference capture groups via \\1). When set, replaces the "
+             "identity-transform path. (env: YB_MCP_IDENTITY_MAP)",
+    )
+    parser.add_argument(
+        "--identity-map-name",
+        default=os.environ.get("YB_MCP_IDENTITY_MAP_NAME", "default"),
+        help="Which named map inside the identity map file to apply. "
+             "(env: YB_MCP_IDENTITY_MAP_NAME, default: default)",
     )
 
     args = parser.parse_args()
@@ -252,6 +307,8 @@ def parse_config() -> ServerConfig:
         enable_write_query=args.enable_write_query,
         identity_claim=args.identity_claim,
         identity_transform=args.identity_transform,
+        identity_map_path=args.identity_map,
+        identity_map_name=args.identity_map_name,
     )
 
 

--- a/src/yugabytedb_mcp_server/server.py
+++ b/src/yugabytedb_mcp_server/server.py
@@ -153,11 +153,14 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[dict]:
             CONFIG.identity_map_path, CONFIG.identity_map_name,
         )
         identity_map = _load_identity_map(CONFIG.identity_map_path)
+        # identity_map is now Dict[map_name, List[MapEntry]]; total = sum of
+        # the inner lists, and the count under the configured name is a
+        # cheap dict lookup.
+        _total = sum(len(v) for v in identity_map.values())
+        _under_name = len(identity_map.get(CONFIG.identity_map_name, []))
         logger.info(
             "Identity map loaded: %d entries (%d under map_name=%s)",
-            len(identity_map),
-            sum(1 for e in identity_map if e.name == CONFIG.identity_map_name),
-            CONFIG.identity_map_name,
+            _total, _under_name, CONFIG.identity_map_name,
         )
 
     if CONFIG.auth_provider:
@@ -170,6 +173,31 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[dict]:
             CONFIG.identity_transform,
             CONFIG.identity_map_path or "<none>",
         )
+        # Fail-closed at startup for the "list-valued claim + no map" combo.
+        # A list claim (e.g. `cognito:groups`, `realm_access.roles`) yields
+        # raw role names from the IdP; without a map file to translate them
+        # into a controlled PG role set, every group name would be used
+        # verbatim as a SET ROLE target — no allowlist. The PR's own
+        # framing says "the map file IS the allowlist," so refuse to start
+        # in this configuration rather than silently granting whatever the
+        # IdP happens to emit.
+        _list_claim_paths = ("cognito:groups", "realm_access.roles", "groups")
+        looks_list_valued = (
+            CONFIG.identity_claim in _list_claim_paths
+            or "." in CONFIG.identity_claim   # dotted paths usually target lists
+        )
+        if identity_map is None and looks_list_valued:
+            raise RuntimeError(
+                f"YB_MCP_IDENTITY_CLAIM={CONFIG.identity_claim!r} typically "
+                f"resolves to a LIST of roles from the IdP, but "
+                f"YB_MCP_IDENTITY_MAP is unset. Without a map, every raw role "
+                f"name from the token would be a candidate SET ROLE target "
+                f"— that removes the allowlist boundary the map is designed "
+                f"to enforce. Configure YB_MCP_IDENTITY_MAP to translate the "
+                f"IdP's role names to a fixed PG role set, or switch "
+                f"YB_MCP_IDENTITY_CLAIM to a scalar claim like `email` or "
+                f"`sub`."
+            )
         if identity_map is None:
             logger.warning(
                 "OIDC identity mapping has no map file configured "

--- a/src/yugabytedb_mcp_server/tools.py
+++ b/src/yugabytedb_mcp_server/tools.py
@@ -149,33 +149,94 @@ def _extract_claim(claims: Dict[str, Any], path: str) -> Any:
     return cursor
 
 
-def _load_identity_map(path: str) -> List[MapEntry]:
-    """Parse a ``pg_ident.conf``-style identity map file.
+def _strip_inline_comment(line: str) -> str:
+    """Return ``line`` with any pg_ident-style comment stripped.
+
+    Only treats ``#`` as a comment marker when it starts the line or is
+    preceded by whitespace. This preserves regexes / role names that
+    contain a literal ``#`` mid-token (e.g. ``/user#\\d+/``).
+    """
+    i = 0
+    while True:
+        j = line.find("#", i)
+        if j < 0:
+            return line
+        if j == 0 or line[j - 1] in " \t":
+            return line[:j]
+        i = j + 1
+
+
+def _validate_db_role_template(
+    role: str, compiled: Optional[re.Pattern], path: str, lineno: int,
+) -> None:
+    """Fail-closed at load time on a db_role template with a broken
+    backreference (``\\N`` referencing a group that doesn't exist).
+
+    Without this, ``m.expand(role)`` would raise ``re.error`` at request
+    time for every match, which surfaces as an unhandled 500 rather than
+    a clean startup refusal.
+    """
+    if compiled is None:
+        # Literal mapping — no expansion, so any bytes are fine.
+        return
+    # sre_parse.parse_template validates group references against the
+    # pattern; anything malformed raises re.error here at LOAD time.
+    try:
+        re.compile(role)  # noqa: F841 -- just to reject obviously invalid
+    except re.error:
+        pass  # role isn't itself a regex; we only care about backref shape
+    # The real check: try an actual expand against a synthetic match. Use a
+    # string that satisfies the pattern (or the empty string if it doesn't
+    # anchor), catch the specific "invalid group reference" family.
+    try:
+        # Compile a throwaway template checker: re.Match.expand triggers
+        # sre_parse.parse_template internally on the template string. We
+        # only need to know if expand would raise for THIS pattern's group
+        # count, which we can get with .groups.
+        n_groups = compiled.groups
+        for ref in re.finditer(r"\\(\d+)", role):
+            g = int(ref.group(1))
+            if g > n_groups:
+                raise ValueError(
+                    f"{path}:{lineno}: db_role template {role!r} references "
+                    f"capture group \\{g}, but the pattern only has "
+                    f"{n_groups} group{'s' if n_groups != 1 else ''}."
+                )
+    except ValueError:
+        raise
+    except re.error as e:
+        raise ValueError(
+            f"{path}:{lineno}: db_role template {role!r} is invalid: {e}"
+        ) from e
+
+
+def _load_identity_map(path: str) -> Dict[str, List[MapEntry]]:
+    """Parse a ``pg_ident.conf``-style identity map file, indexed by map_name.
+
+    Returns a dict of ``map_name → ordered list of that map's entries``. The
+    per-name grouping is done once at startup so ``_apply_map`` doesn't
+    re-filter every entry per value.
 
     Format (matches PostgreSQL's user-name-map file format, used by YSQL's
     ``ysql_ident_conf_csv``):
 
     - Each non-empty, non-comment line has three space-separated fields:
       ``<map_name> <system_value> <db_role>``.
-    - Lines starting with ``#`` (or having ``#`` mid-line for a trailing
-      comment) are treated as comments.
+    - ``#`` starts a comment only at line-start or after whitespace, so a
+      literal ``#`` inside a regex or role name is preserved.
     - ``system_value`` starting with ``/`` is a regex pattern — the rest of
       the field (no closing ``/``) is compiled with ``re.compile`` and
       matched with ``fullmatch``. The ``db_role`` field may reference
       capture groups via ``\\1``, ``\\2``, ....
     - Malformed lines raise ``ValueError`` — caller (server startup) should
       let this propagate to fail-closed instead of silently accepting a
-      typo'd map.
+      typo'd map. Group-reference validity (``\\N`` in db_role) is also
+      checked here.
     """
-    entries: List[MapEntry] = []
+    by_name: Dict[str, List[MapEntry]] = {}
     with open(path) as f:
         for lineno, raw_line in enumerate(f, start=1):
-            # Strip inline comments and surrounding whitespace.
-            line = raw_line.rstrip("\n")
-            hash_idx = line.find("#")
-            if hash_idx >= 0:
-                line = line[:hash_idx]
-            line = line.strip()
+            line = _strip_inline_comment(raw_line.rstrip("\n")).strip()
             if not line:
                 continue
             parts = line.split(None, 2)
@@ -195,37 +256,45 @@ def _load_identity_map(path: str) -> List[MapEntry]:
                     raise ValueError(
                         f"{path}:{lineno}: invalid regex {system_value!r}: {e}"
                     ) from e
-            entries.append(MapEntry(
+            _validate_db_role_template(role, compiled, path, lineno)
+            by_name.setdefault(name, []).append(MapEntry(
                 name=name,
                 pattern=system_value,
                 role=role,
                 is_regex=is_regex,
                 compiled=compiled,
             ))
-    return entries
+    return by_name
 
 
 def _apply_map(
     value: str,
-    entries: List[MapEntry],
+    identity_map: Dict[str, List[MapEntry]],
     map_name: str,
 ) -> Optional[str]:
-    """Try to resolve ``value`` to a DB role via the map entries.
+    """Try to resolve ``value`` to a DB role via the ``map_name`` entries.
 
-    Iterates entries in order; returns the first match's role (with
-    ``\\1``-style substitutions applied for regex entries). Returns ``None``
-    when no entry under ``map_name`` matches the value — caller decides
-    whether "unmapped" is an error (typical) or a fall-through case (never,
-    in this codebase).
+    Iterates the entries under ``map_name`` in order; returns the first
+    match's role (with ``\\1``-style substitutions applied for regex
+    entries). Returns ``None`` when no entry matches the value — caller
+    decides whether "unmapped" is an error (typical) or a fall-through
+    case (never, in this codebase). Also returns ``None`` if a regex
+    match expands to an empty string (a capture group matching ""); an
+    empty role name is never a valid SET ROLE target and would fail with
+    a confusing DB error.
     """
-    for entry in entries:
-        if entry.name != map_name:
-            continue
+    for entry in identity_map.get(map_name, ()):
         if entry.is_regex:
             # PostgreSQL pg_ident.conf matches anchored — use fullmatch.
             m = entry.compiled.fullmatch(value)
             if m is not None:
-                return m.expand(entry.role)
+                expanded = m.expand(entry.role)
+                if expanded == "":
+                    # Empty expansion → treat as unmapped so the caller
+                    # gets a clean IdentityError instead of a downstream
+                    # `SET ROLE ""` failure.
+                    continue
+                return expanded
         else:
             if value == entry.pattern:
                 return entry.role
@@ -241,35 +310,35 @@ def _pick_role(candidates: List[str], requested_role: Optional[str]) -> str:
     cannot pick a role that isn't in the JWT.
 
     Behavior:
-    - Empty candidates → ``IdentityError`` (nothing to pick from).
-    - Single candidate → auto-pick.
-    - Multiple candidates + ``requested_role`` in list → return it.
-    - Multiple candidates + ``requested_role`` NOT in list → ``IdentityError``.
-    - Multiple candidates + ``requested_role is None`` → default to first
-      with a WARNING (documented behavior; agent should pass
-      ``requested_role`` for determinism).
+    - Empty candidates → ``IdentityError``.
+    - Any ``requested_role`` not present in ``candidates`` → ``IdentityError``
+      (regardless of candidate count — a mismatch is never silently ignored).
+    - Single candidate + ``requested_role is None`` → auto-pick.
+    - Multiple candidates + ``requested_role is None`` → ``IdentityError``
+      (fail-closed on ambiguity; the agent must disambiguate explicitly).
+    - Any candidate count + ``requested_role`` in list → return it.
     """
     if not candidates:
         raise IdentityError(
             "None of the identity-claim values resolved to a permitted DB role. "
             "Check YB_MCP_IDENTITY_MAP configuration."
         )
+    if requested_role is not None:
+        if requested_role in candidates:
+            return requested_role
+        raise IdentityError(
+            f"requested_role={requested_role!r} is not in the caller's "
+            f"identity-claim candidates {candidates}. The agent must pick a "
+            f"role that appears in the JWT's mapped list."
+        )
+    # requested_role is None from here on.
     if len(candidates) == 1:
         return candidates[0]
-    if requested_role is None:
-        logger.warning(
-            "Identity claim resolved to multiple roles %s but no requested_role "
-            "was passed. Defaulting to first entry %r. Pass requested_role=<name> "
-            "to disambiguate.",
-            candidates, candidates[0],
-        )
-        return candidates[0]
-    if requested_role in candidates:
-        return requested_role
     raise IdentityError(
-        f"requested_role={requested_role!r} is not in the caller's identity-claim "
-        f"candidates {candidates}. The agent must pick a role that appears in the "
-        f"JWT's mapped list."
+        f"Identity claim resolved to multiple roles {candidates} but no "
+        f"requested_role was passed. Pass requested_role=<name> to pick one — "
+        f"the server refuses to default arbitrarily to avoid granting the "
+        f"more-privileged role by accident."
     )
 
 
@@ -303,7 +372,7 @@ def _get_db_role(ctx: Context, requested_role: Optional[str] = None) -> Optional
     lifespan = ctx.request_context.lifespan_context
     claim_name = lifespan.get("identity_claim", "email")
     transform = lifespan.get("identity_transform", "none")
-    identity_map: Optional[List[MapEntry]] = lifespan.get("identity_map")
+    identity_map: Optional[Dict[str, List[MapEntry]]] = lifespan.get("identity_map")
     identity_map_name: str = lifespan.get("identity_map_name", "default")
 
     _missing_msg = (

--- a/src/yugabytedb_mcp_server/tools.py
+++ b/src/yugabytedb_mcp_server/tools.py
@@ -12,8 +12,10 @@ to the authenticated user's identity.
 
 import json
 import logging
+import re
 from contextlib import contextmanager
-from typing import Any, Dict, List
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
 
 from fastmcp import Context
 from fastmcp.server.dependencies import get_access_token
@@ -38,7 +40,12 @@ def _execute(cur, query, params: tuple | None = None) -> None:
 
 
 def _apply_transform(value: str, transform: str) -> str:
-    """Apply a named transform to a claim value to derive a DB role name."""
+    """Apply a named transform to a claim value to derive a DB role name.
+
+    Backward-compat helper used by the no-map path (when
+    ``YB_MCP_IDENTITY_MAP`` is unset). The map-file path replaces this with
+    an explicit map lookup — see ``_apply_map`` and ``_load_identity_map``.
+    """
     if transform == "strip_domain":
         return value.split("@", 1)[0]
     return value
@@ -48,15 +55,211 @@ class IdentityError(Exception):
     """Raised when an authenticated token lacks the required identity claim."""
 
 
-def _get_db_role(ctx: Context) -> str | None:
+# ---------------------------------------------------------------------------
+# v2 identity mapping — YSQL native OIDC parity.
+#
+# Design mirrors YSQL's `matching_claim_key` + `ysql_ident_conf_csv` (see
+# https://docs.yugabyte.com/stable/yugabyte-platform/security/authentication/oidc-authentication-aad/):
+#
+# - `YB_MCP_IDENTITY_CLAIM` accepts dotted paths (`realm_access.roles`,
+#   `cognito:groups`) — dot walks nested dicts, colon is a literal key char.
+# - Claim value may be a list (e.g. Cognito's `cognito:groups`, Keycloak's
+#   `realm_access.roles`, Azure's `groups`). The caller (agent) selects one
+#   via the tool's `requested_role` parameter; server clamps against the
+#   JWT's list.
+# - `YB_MCP_IDENTITY_MAP` points at a `pg_ident.conf`-style file with
+#   literal or regex entries. When configured, replaces the legacy
+#   `_apply_transform` path.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MapEntry:
+    """One line from the identity map file.
+
+    ``pattern`` is the raw system-value field (kept for error messages);
+    ``compiled`` is the compiled regex when ``is_regex`` is True.
+    """
+    name: str
+    pattern: str
+    role: str
+    is_regex: bool
+    compiled: Optional[re.Pattern] = field(default=None, compare=False)
+
+
+def _extract_claim(claims: Dict[str, Any], path: str) -> Any:
+    """Walk a dotted claim path through the JWT claims dict.
+
+    A dot (``.``) separates path segments; colons (``:``) are part of the
+    key name — Cognito's ``cognito:groups`` is one top-level key, not two
+    nested keys. Missing intermediate segments raise ``IdentityError``.
+
+    Fast path: if ``path`` has no dot, this is a single dict lookup.
+    """
+    if "." not in path:
+        if path not in claims:
+            raise IdentityError(f"Claim {path!r} not found in token")
+        return claims[path]
+
+    parts = path.split(".")
+    cursor: Any = claims
+    for i, segment in enumerate(parts):
+        if not isinstance(cursor, dict):
+            raise IdentityError(
+                f"Claim path {path!r}: cannot descend into non-dict at "
+                f"{'.'.join(parts[:i]) or '<root>'}"
+            )
+        if segment not in cursor:
+            raise IdentityError(
+                f"Claim path {path!r}: key {segment!r} missing at "
+                f"{'.'.join(parts[:i]) or '<root>'}"
+            )
+        cursor = cursor[segment]
+    return cursor
+
+
+def _load_identity_map(path: str) -> List[MapEntry]:
+    """Parse a ``pg_ident.conf``-style identity map file.
+
+    Format (matches PostgreSQL's user-name-map file format, used by YSQL's
+    ``ysql_ident_conf_csv``):
+
+    - Each non-empty, non-comment line has three space-separated fields:
+      ``<map_name> <system_value> <db_role>``.
+    - Lines starting with ``#`` (or having ``#`` mid-line for a trailing
+      comment) are treated as comments.
+    - ``system_value`` starting with ``/`` is a regex pattern — the rest of
+      the field (no closing ``/``) is compiled with ``re.compile`` and
+      matched with ``fullmatch``. The ``db_role`` field may reference
+      capture groups via ``\\1``, ``\\2``, ....
+    - Malformed lines raise ``ValueError`` — caller (server startup) should
+      let this propagate to fail-closed instead of silently accepting a
+      typo'd map.
+    """
+    entries: List[MapEntry] = []
+    with open(path) as f:
+        for lineno, raw_line in enumerate(f, start=1):
+            # Strip inline comments and surrounding whitespace.
+            line = raw_line.rstrip("\n")
+            hash_idx = line.find("#")
+            if hash_idx >= 0:
+                line = line[:hash_idx]
+            line = line.strip()
+            if not line:
+                continue
+            parts = line.split(None, 2)
+            if len(parts) != 3:
+                raise ValueError(
+                    f"{path}:{lineno}: expected 3 space-separated fields "
+                    f"(<map_name> <system_value> <db_role>); got {len(parts)}: {raw_line!r}"
+                )
+            name, system_value, role = parts
+            is_regex = system_value.startswith("/")
+            compiled: Optional[re.Pattern] = None
+            if is_regex:
+                pattern_body = system_value[1:]
+                try:
+                    compiled = re.compile(pattern_body)
+                except re.error as e:
+                    raise ValueError(
+                        f"{path}:{lineno}: invalid regex {system_value!r}: {e}"
+                    ) from e
+            entries.append(MapEntry(
+                name=name,
+                pattern=system_value,
+                role=role,
+                is_regex=is_regex,
+                compiled=compiled,
+            ))
+    return entries
+
+
+def _apply_map(
+    value: str,
+    entries: List[MapEntry],
+    map_name: str,
+) -> Optional[str]:
+    """Try to resolve ``value`` to a DB role via the map entries.
+
+    Iterates entries in order; returns the first match's role (with
+    ``\\1``-style substitutions applied for regex entries). Returns ``None``
+    when no entry under ``map_name`` matches the value — caller decides
+    whether "unmapped" is an error (typical) or a fall-through case (never,
+    in this codebase).
+    """
+    for entry in entries:
+        if entry.name != map_name:
+            continue
+        if entry.is_regex:
+            # PostgreSQL pg_ident.conf matches anchored — use fullmatch.
+            m = entry.compiled.fullmatch(value)
+            if m is not None:
+                return m.expand(entry.role)
+        else:
+            if value == entry.pattern:
+                return entry.role
+    return None
+
+
+def _pick_role(candidates: List[str], requested_role: Optional[str]) -> str:
+    """Choose one role from a list of candidates.
+
+    The user picks any PG role that appears in their
+    roles/groups claim. Here the "user" is the agent, and ``requested_role``
+    is its choice; server clamps against the candidate list so the agent
+    cannot pick a role that isn't in the JWT.
+
+    Behavior:
+    - Empty candidates → ``IdentityError`` (nothing to pick from).
+    - Single candidate → auto-pick.
+    - Multiple candidates + ``requested_role`` in list → return it.
+    - Multiple candidates + ``requested_role`` NOT in list → ``IdentityError``.
+    - Multiple candidates + ``requested_role is None`` → default to first
+      with a WARNING (documented behavior; agent should pass
+      ``requested_role`` for determinism).
+    """
+    if not candidates:
+        raise IdentityError(
+            "None of the identity-claim values resolved to a permitted DB role. "
+            "Check YB_MCP_IDENTITY_MAP configuration."
+        )
+    if len(candidates) == 1:
+        return candidates[0]
+    if requested_role is None:
+        logger.warning(
+            "Identity claim resolved to multiple roles %s but no requested_role "
+            "was passed. Defaulting to first entry %r. Pass requested_role=<name> "
+            "to disambiguate.",
+            candidates, candidates[0],
+        )
+        return candidates[0]
+    if requested_role in candidates:
+        return requested_role
+    raise IdentityError(
+        f"requested_role={requested_role!r} is not in the caller's identity-claim "
+        f"candidates {candidates}. The agent must pick a role that appears in the "
+        f"JWT's mapped list."
+    )
+
+
+def _get_db_role(ctx: Context, requested_role: Optional[str] = None) -> Optional[str]:
     """Extract the database role from the authenticated user's OIDC token.
 
     Returns None when auth is disabled or no token is present (the pool's
     default credentials will be used).
 
-    Raises IdentityError when a token IS present but the required claim is
-    missing — falling back to pool credentials in this case would be a
-    privilege escalation.
+    v2 behavior (see ``_extract_claim`` / ``_apply_map`` / ``_pick_role``):
+    - ``identity_claim`` may be a dotted path (``realm_access.roles``,
+      ``cognito:groups``).
+    - Claim may be a list — ``requested_role`` selects one; server clamps
+      against the JWT's list.
+    - When ``YB_MCP_IDENTITY_MAP`` is configured, the resolved claim value(s)
+      go through ``_apply_map`` (pg_ident.conf-style lookup). Otherwise the
+      legacy ``_apply_transform`` path runs (v1 backward-compat).
+
+    Raises ``IdentityError`` when a token IS present but the claim resolves
+    to nothing — falling back to pool credentials would be a privilege
+    escalation.
     """
     try:
         token = get_access_token()
@@ -69,16 +272,53 @@ def _get_db_role(ctx: Context) -> str | None:
     lifespan = ctx.request_context.lifespan_context
     claim_name = lifespan.get("identity_claim", "email")
     transform = lifespan.get("identity_transform", "none")
+    identity_map: Optional[List[MapEntry]] = lifespan.get("identity_map")
+    identity_map_name: str = lifespan.get("identity_map_name", "default")
 
-    claim_value = token.claims.get(claim_name)
-    if not claim_value:
-        raise IdentityError(
-            f"Token present but required claim {claim_name!r} is missing or empty. "
-            f"Cannot determine database role for authenticated user."
-        )
+    _missing_msg = (
+        f"Token present but required claim {claim_name!r} is missing or empty. "
+        f"Cannot determine database role for authenticated user."
+    )
 
-    role = _apply_transform(str(claim_value), transform)
-    logger.debug("Resolved DB role %r from claim %r=%r", role, claim_name, claim_value)
+    # 1. Extract claim (supports dotted paths).
+    try:
+        claim_value = _extract_claim(token.claims, claim_name)
+    except IdentityError:
+        # Normalize to the v1 error message shape so existing callers /
+        # tests get an identical string on the "missing claim" path.
+        raise IdentityError(_missing_msg)
+
+    # 2. Normalize the claim to a list of non-empty string values. This is
+    #    where scalar and list-valued claims converge into one code path.
+    if isinstance(claim_value, list):
+        raw_values = [str(v) for v in claim_value if v]
+        if not raw_values:
+            raise IdentityError(_missing_msg)
+    else:
+        if not claim_value:
+            raise IdentityError(_missing_msg)
+        raw_values = [str(claim_value)]
+
+    # 3. Resolve each raw value to a candidate role.
+    #    - With a map: apply pg_ident-style lookup; drop unmapped values.
+    #    - Without a map (v1 backward-compat): apply transform to each.
+    if identity_map is not None:
+        candidates: List[str] = []
+        for v in raw_values:
+            mapped = _apply_map(v, identity_map, identity_map_name)
+            if mapped is not None:
+                candidates.append(mapped)
+    else:
+        candidates = [_apply_transform(v, transform) for v in raw_values]
+
+    # 4. Pick one role.
+    role = _pick_role(candidates, requested_role)
+
+    logger.debug(
+        "Resolved DB role %r from claim %r (raw=%s, candidates=%s, requested=%r, mapped=%s)",
+        role, claim_name, raw_values, candidates, requested_role,
+        identity_map is not None,
+    )
     return role
 
 
@@ -103,7 +343,11 @@ def _conn_as_role(pool, role: str | None):
                 logger.debug("RESET ROLE")
 
 
-def summarize_database(ctx: Context, schema: str = "public") -> List[Dict[str, Any]]:
+def summarize_database(
+    ctx: Context,
+    schema: str = "public",
+    requested_role: Optional[str] = None,
+) -> List[Dict[str, Any]]:
     """
     Summarize a database schema: list every table with its column schema and
     row count.
@@ -115,13 +359,18 @@ def summarize_database(ctx: Context, schema: str = "public") -> List[Dict[str, A
     Args:
         ctx: MCP context (injected automatically).
         schema: Schema name to inspect (default: ``public``).
+        requested_role: When the identity-claim JWT value is a list (e.g.
+            ``cognito:groups=["writer","reader"]``), pick which role to
+            SET ROLE to. Must be a value that appears in the mapped
+            candidate list — the server clamps against the JWT. Ignored
+            when the claim is a scalar (single email/sub/etc.).
     """
     logger.info("summarize_database called (schema=%s)", schema)
     summary: List[Dict[str, Any]] = []
     pool = ctx.request_context.lifespan_context["pool"]
 
     try:
-        role = _get_db_role(ctx)
+        role = _get_db_role(ctx, requested_role=requested_role)
     except IdentityError as e:
         logger.error("Identity resolution failed: %s", e)
         return [{"error": str(e)}]
@@ -186,7 +435,11 @@ def summarize_database(ctx: Context, schema: str = "public") -> List[Dict[str, A
     return summary
 
 
-def run_read_only_query(ctx: Context, query: str) -> str:
+def run_read_only_query(
+    ctx: Context,
+    query: str,
+    requested_role: Optional[str] = None,
+) -> str:
     """
     Run a read-only SQL query under BEGIN READ ONLY and return the rows as
     JSON.
@@ -197,13 +450,17 @@ def run_read_only_query(ctx: Context, query: str) -> str:
     Args:
         ctx: MCP context (injected automatically).
         query: SQL statement (typically SELECT) to execute.
+        requested_role: When the identity-claim JWT value is a list (e.g.
+            ``cognito:groups=["writer","reader"]``), pick which role to
+            SET ROLE to. Must be a value that appears in the mapped
+            candidate list — the server clamps against the JWT.
     """
     logger.info("run_read_only_query called")
     logger.debug("Query: %s", query)
     pool = ctx.request_context.lifespan_context["pool"]
 
     try:
-        role = _get_db_role(ctx)
+        role = _get_db_role(ctx, requested_role=requested_role)
     except IdentityError as e:
         logger.error("Identity resolution failed: %s", e)
         return json.dumps({"error": str(e)})
@@ -232,7 +489,11 @@ def run_read_only_query(ctx: Context, query: str) -> str:
                     logger.error("Failed to ROLLBACK read-only transaction: %s", e)
 
 
-def run_write_query(ctx: Context, query: str) -> str:
+def run_write_query(
+    ctx: Context,
+    query: str,
+    requested_role: Optional[str] = None,
+) -> str:
     """
     Execute a write SQL statement (INSERT/UPDATE/DELETE/MERGE/TRUNCATE/DDL)
     after guardrail validation. Returns a JSON object with `rows_affected`
@@ -248,6 +509,10 @@ def run_write_query(ctx: Context, query: str) -> str:
     Args:
         ctx: MCP context (injected automatically).
         query: SQL statement to execute.
+        requested_role: When the identity-claim JWT value is a list, pick
+            which role to SET ROLE to for this write. Must be a value that
+            appears in the mapped candidate list — server clamps against
+            the JWT.
     """
     logger.info("run_write_query called")
     logger.debug("Query: %s", query)
@@ -262,7 +527,7 @@ def run_write_query(ctx: Context, query: str) -> str:
         return json.dumps({"error": str(e), "blocked_by_guardrail": True})
 
     try:
-        role = _get_db_role(ctx)
+        role = _get_db_role(ctx, requested_role=requested_role)
     except IdentityError as e:
         logger.error("Identity resolution failed: %s", e)
         return json.dumps({"error": str(e)})

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -286,18 +286,20 @@ async def test_jwt_verifier_accepts_matching_audience(rsa_keypair):
     assert result is not None
 
 
-def test_cognito_provider_wires_client_id_as_audience():
+def test_cognito_provider_wires_client_id_as_expected_audience():
     """DB-22136: _create_cognito must pass COGNITO_CLIENT_ID as the
-    JWTVerifier's audience so tokens for other same-pool clients are
-    rejected. Reads the verifier's audience via the MultiAuth wiring."""
+    verifier's expected audience so tokens for other same-pool clients are
+    rejected. The custom `_CognitoJWTVerifier` stores this on
+    `_expected_audience` (the parent JWTVerifier's `audience` attribute is
+    intentionally None because Cognito access tokens omit the `aud` claim
+    and put the identifier in `client_id`; the subclass handles both)."""
     with patch.dict("os.environ", COGNITO_ENV, clear=False), \
          patch("httpx.get", side_effect=_mock_httpx_get):
         provider = _create_cognito()
-    # MultiAuth exposes verifiers as a list; our custom subclass sits there.
     verifier = provider.verifiers[0]
-    # JWTVerifier stores audience in a public attribute — mypy may need
-    # `# type: ignore` since it's not in the type stubs.
-    assert getattr(verifier, "audience", None) == COGNITO_ENV["COGNITO_CLIENT_ID"]
+    assert verifier._expected_audience == COGNITO_ENV["COGNITO_CLIENT_ID"]
+    # Parent's audience is disabled — our subclass handles it.
+    assert getattr(verifier, "audience", None) is None
 
 
 # ---------------------------------------------------------------------------
@@ -381,7 +383,10 @@ async def test_id_token_rejected_when_require_access_on(rsa_keypair, caplog):
 
 @pytest.mark.asyncio
 async def test_access_token_accepted_when_require_access_on(rsa_keypair):
-    """Regression: access tokens still pass with require_access=true."""
+    """Access tokens with the Cognito-native shape (no `aud`; identity in
+    `client_id`) must pass with require_access=true. This is the real
+    shape Cognito mints — see the module docstring on
+    _CognitoJWTVerifier for why."""
     with patch.dict("os.environ", {**COGNITO_ENV, "YB_MCP_REQUIRE_ACCESS_TOKEN": "true"}), \
          patch("httpx.get", side_effect=_mock_httpx_get):
         provider = _create_cognito()
@@ -392,10 +397,11 @@ async def test_access_token_accepted_when_require_access_on(rsa_keypair):
     verifier.algorithm = "RS256"
 
     now = datetime.datetime.now(datetime.timezone.utc)
+    # Real-Cognito access token: no `aud`, identity in `client_id`.
     access_token_claims = {
         "iss": FAKE_ISSUER,
         "sub": "user",
-        "aud": COGNITO_ENV["COGNITO_CLIENT_ID"],
+        "client_id": COGNITO_ENV["COGNITO_CLIENT_ID"],
         "token_use": "access",
         "cognito:groups": ["writer", "reader"],
         "exp": now + datetime.timedelta(minutes=5),
@@ -404,7 +410,40 @@ async def test_access_token_accepted_when_require_access_on(rsa_keypair):
     token = _sign_jwt(access_token_claims, rsa_keypair["private_pem"])
 
     result = await verifier.verify_token(token)
-    assert result is not None
+    assert result is not None, "Cognito-shape access token (no aud, has client_id) was rejected"
+
+
+@pytest.mark.asyncio
+async def test_access_token_wrong_client_id_rejected(rsa_keypair, caplog):
+    """DB-22136: an access token minted for a different app client in the
+    same pool must be rejected. Real Cognito tokens carry the identifier
+    in `client_id`, not `aud`, so the check must inspect both."""
+    with patch.dict("os.environ", COGNITO_ENV, clear=False), \
+         patch("httpx.get", side_effect=_mock_httpx_get):
+        provider = _create_cognito()
+    verifier = provider.verifiers[0]
+    verifier._public_key = rsa_keypair["public_pem"].decode()
+    verifier.public_key = rsa_keypair["public_pem"].decode()
+    verifier.algorithm = "RS256"
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    # Wrong client_id — pretends to be another app client in the pool.
+    access_token_claims = {
+        "iss": FAKE_ISSUER,
+        "sub": "user",
+        "client_id": "another-client-in-same-pool",
+        "token_use": "access",
+        "exp": now + datetime.timedelta(minutes=5),
+        "iat": now,
+    }
+    token = _sign_jwt(access_token_claims, rsa_keypair["private_pem"])
+
+    with caplog.at_level("WARNING"):
+        result = await verifier.verify_token(token)
+
+    assert result is None, "wrong-client_id access token should be rejected"
+    assert any("audience mismatch" in r.message for r in caplog.records), \
+        "expected an audience-mismatch WARNING"
 
 
 @pytest.mark.asyncio

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -224,3 +224,258 @@ async def test_jwt_verifier_rejects_tampered_signature(rsa_keypair):
 
     result = await verifier.verify_token(tampered)
     assert result is None
+
+
+# ---------------------------------------------------------------------------
+# DB-22136: audience validation
+# ---------------------------------------------------------------------------
+# The pre-fix code passed no `audience=` to JWTVerifier, so a token minted
+# for a different app client in the same Cognito user pool was accepted at
+# /mcp. Fix: pass the expected audience (Cognito's app-client_id) to
+# JWTVerifier. These tests exercise the raw JWTVerifier with `audience=`
+# because that's the guarantee we rely on in _create_cognito.
+
+@pytest.mark.asyncio
+async def test_jwt_verifier_rejects_wrong_audience(rsa_keypair):
+    """DB-22136: token minted for another client (different `aud`) must be
+    rejected once audience validation is enabled."""
+    from fastmcp.server.auth.providers.jwt import JWTVerifier
+
+    verifier = JWTVerifier(
+        public_key=rsa_keypair["public_pem"].decode(),
+        issuer=FAKE_ISSUER,
+        audience="expected-client-id",
+        algorithm="RS256",
+    )
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    claims = {
+        "iss": FAKE_ISSUER,
+        "sub": "some-user",
+        "aud": "OTHER-app-client",       # different client in same pool
+        "exp": now + datetime.timedelta(minutes=5),
+        "iat": now,
+    }
+    token = _sign_jwt(claims, rsa_keypair["private_pem"])
+    result = await verifier.verify_token(token)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_jwt_verifier_accepts_matching_audience(rsa_keypair):
+    """Regression: correct audience continues to pass."""
+    from fastmcp.server.auth.providers.jwt import JWTVerifier
+
+    verifier = JWTVerifier(
+        public_key=rsa_keypair["public_pem"].decode(),
+        issuer=FAKE_ISSUER,
+        audience="expected-client-id",
+        algorithm="RS256",
+    )
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    claims = {
+        "iss": FAKE_ISSUER,
+        "sub": "some-user",
+        "aud": "expected-client-id",
+        "exp": now + datetime.timedelta(minutes=5),
+        "iat": now,
+    }
+    token = _sign_jwt(claims, rsa_keypair["private_pem"])
+    result = await verifier.verify_token(token)
+    assert result is not None
+
+
+def test_cognito_provider_wires_client_id_as_audience():
+    """DB-22136: _create_cognito must pass COGNITO_CLIENT_ID as the
+    JWTVerifier's audience so tokens for other same-pool clients are
+    rejected. Reads the verifier's audience via the MultiAuth wiring."""
+    with patch.dict("os.environ", COGNITO_ENV, clear=False), \
+         patch("httpx.get", side_effect=_mock_httpx_get):
+        provider = _create_cognito()
+    # MultiAuth exposes verifiers as a list; our custom subclass sits there.
+    verifier = provider.verifiers[0]
+    # JWTVerifier stores audience in a public attribute — mypy may need
+    # `# type: ignore` since it's not in the type stubs.
+    assert getattr(verifier, "audience", None) == COGNITO_ENV["COGNITO_CLIENT_ID"]
+
+
+# ---------------------------------------------------------------------------
+# DB-22136: token_use=access enforcement (Cognito, opt-in)
+# ---------------------------------------------------------------------------
+# _CognitoJWTVerifier rejects tokens where `token_use != "access"` when
+# YB_MCP_REQUIRE_ACCESS_TOKEN=true. Default off for backward compat with
+# email-in-ID-token deployments (see DB-22192).
+
+@pytest.mark.asyncio
+async def test_id_token_accepted_when_require_access_off(rsa_keypair, caplog):
+    """Default config: ID tokens are accepted; a WARNING is logged so
+    operators see they should migrate."""
+    with patch.dict("os.environ", {**COGNITO_ENV}, clear=False), \
+         patch("httpx.get", side_effect=_mock_httpx_get):
+        # Ensure the toggle is off (default)
+        with patch.dict("os.environ", {"YB_MCP_REQUIRE_ACCESS_TOKEN": "false"}):
+            provider = _create_cognito()
+
+    verifier = provider.verifiers[0]
+    # Swap the verifier's JWKS-based key path for our test RSA key so we can
+    # sign tokens locally. JWTVerifier accepts `public_key` at construction;
+    # since we're testing the subclass logic, patch its key resolution.
+    verifier._public_key = rsa_keypair["public_pem"].decode()
+    verifier.public_key = rsa_keypair["public_pem"].decode()
+    verifier.algorithm = "RS256"
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    id_token_claims = {
+        "iss": FAKE_ISSUER,
+        "sub": "user",
+        "aud": COGNITO_ENV["COGNITO_CLIENT_ID"],
+        "token_use": "id",                  # ID token, not access
+        "email": "alice@example.com",
+        "exp": now + datetime.timedelta(minutes=5),
+        "iat": now,
+    }
+    token = _sign_jwt(id_token_claims, rsa_keypair["private_pem"])
+
+    with caplog.at_level("WARNING"):
+        result = await verifier.verify_token(token)
+
+    assert result is not None, "ID token accepted when require_access is off"
+    assert any("ID token" in r.message for r in caplog.records), \
+        "expected a WARNING about accepted ID token"
+
+
+@pytest.mark.asyncio
+async def test_id_token_rejected_when_require_access_on(rsa_keypair, caplog):
+    """`YB_MCP_REQUIRE_ACCESS_TOKEN=true` rejects ID tokens outright."""
+    with patch.dict("os.environ", {**COGNITO_ENV, "YB_MCP_REQUIRE_ACCESS_TOKEN": "true"}), \
+         patch("httpx.get", side_effect=_mock_httpx_get):
+        provider = _create_cognito()
+
+    verifier = provider.verifiers[0]
+    verifier._public_key = rsa_keypair["public_pem"].decode()
+    verifier.public_key = rsa_keypair["public_pem"].decode()
+    verifier.algorithm = "RS256"
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    id_token_claims = {
+        "iss": FAKE_ISSUER,
+        "sub": "user",
+        "aud": COGNITO_ENV["COGNITO_CLIENT_ID"],
+        "token_use": "id",
+        "email": "alice@example.com",
+        "exp": now + datetime.timedelta(minutes=5),
+        "iat": now,
+    }
+    token = _sign_jwt(id_token_claims, rsa_keypair["private_pem"])
+
+    with caplog.at_level("WARNING"):
+        result = await verifier.verify_token(token)
+
+    assert result is None, "ID token should be rejected when require_access is on"
+    assert any(
+        "token_use" in r.message and "id" in r.message.lower()
+        for r in caplog.records
+    ), "expected a WARNING mentioning token_use=id"
+
+
+@pytest.mark.asyncio
+async def test_access_token_accepted_when_require_access_on(rsa_keypair):
+    """Regression: access tokens still pass with require_access=true."""
+    with patch.dict("os.environ", {**COGNITO_ENV, "YB_MCP_REQUIRE_ACCESS_TOKEN": "true"}), \
+         patch("httpx.get", side_effect=_mock_httpx_get):
+        provider = _create_cognito()
+
+    verifier = provider.verifiers[0]
+    verifier._public_key = rsa_keypair["public_pem"].decode()
+    verifier.public_key = rsa_keypair["public_pem"].decode()
+    verifier.algorithm = "RS256"
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    access_token_claims = {
+        "iss": FAKE_ISSUER,
+        "sub": "user",
+        "aud": COGNITO_ENV["COGNITO_CLIENT_ID"],
+        "token_use": "access",
+        "cognito:groups": ["writer", "reader"],
+        "exp": now + datetime.timedelta(minutes=5),
+        "iat": now,
+    }
+    token = _sign_jwt(access_token_claims, rsa_keypair["private_pem"])
+
+    result = await verifier.verify_token(token)
+    assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_rejected_when_require_access_on(rsa_keypair):
+    """token_use=refresh presented as a bearer is also rejected."""
+    with patch.dict("os.environ", {**COGNITO_ENV, "YB_MCP_REQUIRE_ACCESS_TOKEN": "true"}), \
+         patch("httpx.get", side_effect=_mock_httpx_get):
+        provider = _create_cognito()
+
+    verifier = provider.verifiers[0]
+    verifier._public_key = rsa_keypair["public_pem"].decode()
+    verifier.public_key = rsa_keypair["public_pem"].decode()
+    verifier.algorithm = "RS256"
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    refresh_claims = {
+        "iss": FAKE_ISSUER,
+        "sub": "user",
+        "aud": COGNITO_ENV["COGNITO_CLIENT_ID"],
+        "token_use": "refresh",
+        "exp": now + datetime.timedelta(minutes=5),
+        "iat": now,
+    }
+    token = _sign_jwt(refresh_claims, rsa_keypair["private_pem"])
+    result = await verifier.verify_token(token)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# DB-22136: OIDC path forwards OIDC_AUDIENCE to the verifier
+# ---------------------------------------------------------------------------
+
+def test_oidc_provider_wires_audience_env_to_verifier():
+    """_create_oidc must pass OIDC_AUDIENCE (already read for OIDCProxy)
+    to JWTVerifier as well, so signature+issuer isn't the only check."""
+    from yugabytedb_mcp_server.auth import _create_oidc
+
+    oidc_env = {
+        "OIDC_CONFIG_URL": f"{FAKE_ISSUER}/.well-known/openid-configuration",
+        "OIDC_CLIENT_ID": "oidc-client",
+        "OIDC_CLIENT_SECRET": "oidc-secret",
+        "OIDC_AUDIENCE": "expected-oidc-audience",
+        "MCP_BASE_URL": "http://localhost:8000",
+    }
+    with patch.dict("os.environ", oidc_env, clear=False), \
+         patch("httpx.get", side_effect=_mock_httpx_get):
+        provider = _create_oidc()
+
+    verifier = provider.verifiers[0]
+    assert getattr(verifier, "audience", None) == "expected-oidc-audience"
+
+
+def test_oidc_provider_warns_when_audience_missing(caplog):
+    """No OIDC_AUDIENCE → a startup WARNING logs that only signature +
+    issuer are checked; provider still constructs (backward compat)."""
+    from yugabytedb_mcp_server.auth import _create_oidc
+
+    oidc_env = {
+        "OIDC_CONFIG_URL": f"{FAKE_ISSUER}/.well-known/openid-configuration",
+        "OIDC_CLIENT_ID": "oidc-client",
+        "OIDC_CLIENT_SECRET": "oidc-secret",
+        # OIDC_AUDIENCE deliberately absent
+        "MCP_BASE_URL": "http://localhost:8000",
+    }
+    with patch.dict("os.environ", oidc_env, clear=True), \
+         patch("httpx.get", side_effect=_mock_httpx_get), \
+         caplog.at_level("WARNING"):
+        provider = _create_oidc()
+
+    verifier = provider.verifiers[0]
+    assert getattr(verifier, "audience", None) is None
+    assert any(
+        "OIDC_AUDIENCE" in r.message for r in caplog.records
+    ), "expected a WARNING mentioning OIDC_AUDIENCE"

--- a/tests/test_identity_mapping.py
+++ b/tests/test_identity_mapping.py
@@ -1,17 +1,38 @@
 """Unit tests for OIDC identity → DB role mapping logic.
 
-No database or MCP session required — these test the pure extraction and
-transform functions in tools.py.
+No database or MCP session required — these test the pure extraction,
+transform, and mapping functions in tools.py.
+
+Layout:
+- TestApplyTransform / TestGetDbRole — v1 backward-compat harness (must
+  stay green when v2 features are unset).
+- TestExtractClaim — v2 dotted-path claim extraction.
+- TestMapFileParser — v2 pg_ident.conf-style map file parsing.
+- TestApplyMap — v2 map-entry matching (literal + regex + capture).
+- TestPickRole — v2 list-claim role selection 
+- TestGetDbRoleV2 — end-to-end v2 wiring on `_get_db_role`.
+- TestFailClosed — malformed/missing map files at load time.
+- TestSecurityInvariants — role-name Identifier quoting, empty-list handling.
 """
+import re
 from unittest.mock import patch, MagicMock
 
 import pytest
 
-from yugabytedb_mcp_server.tools import _apply_transform, _get_db_role, IdentityError
+from yugabytedb_mcp_server.tools import (
+    IdentityError,
+    MapEntry,
+    _apply_map,
+    _apply_transform,
+    _extract_claim,
+    _get_db_role,
+    _load_identity_map,
+    _pick_role,
+)
 
 
 # ---------------------------------------------------------------------------
-# _apply_transform
+# _apply_transform — v1 backward-compat helper
 # ---------------------------------------------------------------------------
 
 class TestApplyTransform:
@@ -32,15 +53,27 @@ class TestApplyTransform:
 
 
 # ---------------------------------------------------------------------------
-# _get_db_role
+# Test helpers
 # ---------------------------------------------------------------------------
 
-def _make_ctx(identity_claim="email", identity_transform="none"):
-    """Create a minimal mock Context with lifespan_context."""
+def _make_ctx(
+    identity_claim="email",
+    identity_transform="none",
+    identity_map=None,
+    identity_map_name="default",
+):
+    """Create a minimal mock Context with lifespan_context.
+
+    Passing ``identity_map=None`` (default) selects the v1 backward-compat
+    path via ``_apply_transform``; passing a list of ``MapEntry`` selects the
+    v2 map-lookup path.
+    """
     ctx = MagicMock()
     ctx.request_context.lifespan_context = {
         "identity_claim": identity_claim,
         "identity_transform": identity_transform,
+        "identity_map": identity_map,
+        "identity_map_name": identity_map_name,
     }
     return ctx
 
@@ -51,6 +84,10 @@ def _make_access_token(claims: dict):
     token.claims = claims
     return token
 
+
+# ---------------------------------------------------------------------------
+# _get_db_role — v1 backward-compat regression harness
+# ---------------------------------------------------------------------------
 
 class TestGetDbRole:
     @patch("yugabytedb_mcp_server.tools.get_access_token")
@@ -96,3 +133,442 @@ class TestGetDbRole:
     def test_runtime_error_returns_none(self, mock_get_token):
         ctx = _make_ctx()
         assert _get_db_role(ctx) is None
+
+
+# ===========================================================================
+# v2 mapping tests below.
+# ===========================================================================
+
+
+# ---------------------------------------------------------------------------
+# _extract_claim — dotted-path claim extraction
+# ---------------------------------------------------------------------------
+# YSQL parity: dots separate nested-dict path segments; colons are literal
+# key chars (Cognito's `cognito:groups` is one key, not two).
+
+class TestExtractClaim:
+    def test_top_level_string(self):
+        claims = {"email": "bob@a.com"}
+        assert _extract_claim(claims, "email") == "bob@a.com"
+
+    def test_top_level_list(self):
+        claims = {"roles": ["writer", "reader"]}
+        assert _extract_claim(claims, "roles") == ["writer", "reader"]
+
+    def test_dotted_path(self):
+        """Keycloak-style `realm_access.roles` walks the nested dict."""
+        claims = {"realm_access": {"roles": ["writer"]}}
+        assert _extract_claim(claims, "realm_access.roles") == ["writer"]
+
+    def test_dotted_path_deep(self):
+        claims = {"a": {"b": {"c": "deep"}}}
+        assert _extract_claim(claims, "a.b.c") == "deep"
+
+    def test_dotted_with_colon(self):
+        """Cognito's `cognito:groups` is a top-level key with a colon —
+        NOT a dotted path. Verify the colon doesn't split."""
+        claims = {"cognito:groups": ["reader", "writer"]}
+        assert _extract_claim(claims, "cognito:groups") == ["reader", "writer"]
+
+    def test_missing_top_level_key(self):
+        with pytest.raises(IdentityError, match="email"):
+            _extract_claim({"sub": "x"}, "email")
+
+    def test_missing_intermediate_key(self):
+        """`a.b.c` where `a` exists but has no `b` — error mentions the path."""
+        with pytest.raises(IdentityError, match=r"a\.b\.c"):
+            _extract_claim({"a": {}}, "a.b.c")
+
+    def test_missing_final_key(self):
+        with pytest.raises(IdentityError, match=r"a\.b\.c"):
+            _extract_claim({"a": {"b": {}}}, "a.b.c")
+
+    def test_cannot_descend_into_non_dict(self):
+        """`a.b` where `a` is a string — error says can't descend."""
+        with pytest.raises(IdentityError, match="cannot descend"):
+            _extract_claim({"a": "scalar"}, "a.b")
+
+
+# ---------------------------------------------------------------------------
+# _load_identity_map — pg_ident.conf-style parser
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def map_file_factory(tmp_path):
+    """Return a callable that writes given content to a tmp file and returns its path."""
+    def _write(content: str, name: str = "yb_ident.conf") -> str:
+        p = tmp_path / name
+        p.write_text(content)
+        return str(p)
+    return _write
+
+
+class TestMapFileParser:
+    def test_literal_entry(self, map_file_factory):
+        path = map_file_factory("map1  user@yugabyte.com  user\n")
+        entries = _load_identity_map(path)
+        assert len(entries) == 1
+        assert entries[0] == MapEntry(
+            name="map1", pattern="user@yugabyte.com", role="user",
+            is_regex=False, compiled=None,
+        )
+
+    def test_regex_entry(self, map_file_factory):
+        """From the YSQL docs, verbatim."""
+        path = map_file_factory(
+            "map2  /^(.*)@devadmincloudyugabyte\\.onmicrosoft\\.com$  \\1\n"
+        )
+        entries = _load_identity_map(path)
+        assert entries[0].is_regex is True
+        assert entries[0].compiled is not None
+        assert entries[0].role == r"\1"
+
+    def test_role_to_role_entry(self, map_file_factory):
+        """From the YSQL docs, verbatim: OIDC group name → PG role name."""
+        path = map_file_factory("map1  OIDC.Test.Read  read_only_user\n")
+        entries = _load_identity_map(path)
+        assert entries[0].pattern == "OIDC.Test.Read"
+        assert entries[0].role == "read_only_user"
+        assert entries[0].is_regex is False
+
+    def test_azure_guid_regex(self, map_file_factory):
+        """Azure AD group GUID → readable role via regex. Follows the YSQL
+        docs convention: leading `/` marks the pattern as regex; NO closing
+        `/` (the rest of the field is the regex body verbatim)."""
+        path = map_file_factory("azure  /^a12d04b1-.+  reader\n")
+        entries = _load_identity_map(path)
+        assert entries[0].compiled.fullmatch("a12d04b1-7463-8e23-94d2-8d71f17ab99b")
+
+    def test_comments_and_blank_lines_ignored(self, map_file_factory):
+        path = map_file_factory(
+            "# leading comment\n"
+            "\n"
+            "map1  alice  a_role\n"
+            "  # indented comment\n"
+            "\n"
+            "map1  bob    b_role  # trailing comment\n"
+        )
+        entries = _load_identity_map(path)
+        assert len(entries) == 2
+        assert entries[0].pattern == "alice"
+        assert entries[1].pattern == "bob"
+
+    def test_multiple_named_maps(self, map_file_factory):
+        path = map_file_factory(
+            "default  alice  a_role\n"
+            "azure    bob    b_role\n"
+            "default  carol  c_role\n"
+        )
+        entries = _load_identity_map(path)
+        assert [e.name for e in entries] == ["default", "azure", "default"]
+
+    def test_malformed_regex_line_raises(self, map_file_factory):
+        path = map_file_factory("map1  /[unterminated  reader\n")
+        with pytest.raises(ValueError, match="invalid regex"):
+            _load_identity_map(path)
+
+    def test_wrong_field_count_raises(self, map_file_factory):
+        path = map_file_factory("map1  too_few\n")
+        with pytest.raises(ValueError, match="3 space-separated"):
+            _load_identity_map(path)
+
+    def test_extra_fields_collapse_into_role(self, map_file_factory):
+        """Fourth+ whitespace-separated fields become part of the role value —
+        pg_ident allows this and users occasionally have role names with
+        embedded whitespace. Documents current behavior."""
+        # split(None, 2) collapses trailing whitespace into field 3
+        path = map_file_factory("map1 alice role_with_spaces\n")
+        entries = _load_identity_map(path)
+        assert entries[0].role == "role_with_spaces"
+
+    def test_nonexistent_file_raises(self, tmp_path):
+        with pytest.raises((FileNotFoundError, OSError)):
+            _load_identity_map(str(tmp_path / "does-not-exist.conf"))
+
+
+# ---------------------------------------------------------------------------
+# _apply_map — match a value against map entries
+# ---------------------------------------------------------------------------
+
+def _literal(name: str, pattern: str, role: str) -> MapEntry:
+    return MapEntry(name=name, pattern=pattern, role=role, is_regex=False, compiled=None)
+
+
+def _regex(name: str, pattern: str, role: str) -> MapEntry:
+    return MapEntry(
+        name=name, pattern="/" + pattern, role=role, is_regex=True,
+        compiled=re.compile(pattern),
+    )
+
+
+class TestApplyMap:
+    def test_literal_match(self):
+        entries = [_literal("default", "bob@yugabyte.com", "writer")]
+        assert _apply_map("bob@yugabyte.com", entries, "default") == "writer"
+
+    def test_regex_capture(self):
+        entries = [_regex("default", r"^([a-z]+)@yugabyte\.com$", r"\1")]
+        assert _apply_map("carol@yugabyte.com", entries, "default") == "carol"
+
+    def test_role_to_role_literal(self):
+        entries = [_literal("default", "OIDC.Test.Read", "read_only_user")]
+        assert _apply_map("OIDC.Test.Read", entries, "default") == "read_only_user"
+
+    def test_azure_guid_regex(self):
+        entries = [_regex("azure", r"^a12d04b1-.+", "reader")]
+        assert _apply_map(
+            "a12d04b1-7463-8e23-94d2-8d71f17ab99b", entries, "azure",
+        ) == "reader"
+
+    def test_unmapped_returns_none(self):
+        entries = [_literal("default", "alice", "a")]
+        assert _apply_map("someone-else", entries, "default") is None
+
+    def test_map_name_filter(self):
+        """Entries under a different map_name must not match."""
+        entries = [
+            _literal("default", "alice", "wrong"),
+            _literal("azure", "alice", "right"),
+        ]
+        assert _apply_map("alice", entries, "azure") == "right"
+
+    def test_map_name_isolation_no_leak(self):
+        """A `default` entry must not match under `map_name="azure"`."""
+        entries = [_literal("default", "alice", "a")]
+        assert _apply_map("alice", entries, "azure") is None
+
+    def test_regex_is_anchored(self):
+        """Regex uses fullmatch — a pattern without explicit anchors still
+        requires the whole value to match, mirroring pg_ident.conf."""
+        entries = [_regex("default", r"foo", "matched")]
+        assert _apply_map("foo", entries, "default") == "matched"
+        assert _apply_map("foobar", entries, "default") is None  # not anchored via search
+
+    def test_first_match_wins(self):
+        """When multiple entries under the same map_name could match, the
+        first one wins (mirrors pg_ident.conf iteration order)."""
+        entries = [
+            _literal("default", "alice", "first"),
+            _literal("default", "alice", "second"),
+        ]
+        assert _apply_map("alice", entries, "default") == "first"
+
+
+# ---------------------------------------------------------------------------
+# _pick_role — list-claim role selection
+# ---------------------------------------------------------------------------
+# User can take any PG role that is in their roles/groups claim". 
+# The MCP tool's `requested_role` is the caller
+# (agent)'s choice; server clamps against the candidate list.
+
+class TestPickRole:
+    def test_single_candidate_auto_pick(self):
+        assert _pick_role(["writer"], None) == "writer"
+
+    def test_single_candidate_ignores_requested_role(self):
+        """One candidate is always picked, even if requested_role is different
+        (we could raise here — but the ergonomic choice is auto-pick since
+        the caller had exactly one option)."""
+        assert _pick_role(["writer"], "reader") == "writer"
+
+    def test_multi_candidate_requested_role_in_list(self):
+        assert _pick_role(["writer", "reader"], "reader") == "reader"
+
+    def test_multi_candidate_requested_role_not_in_list_raises(self):
+        with pytest.raises(IdentityError, match="not in the caller's identity-claim"):
+            _pick_role(["writer", "reader"], "admin")
+
+    def test_multi_candidate_no_request_defaults_to_first(self, caplog):
+        with caplog.at_level("WARNING"):
+            assert _pick_role(["writer", "reader"], None) == "writer"
+        assert any("multiple roles" in r.message for r in caplog.records)
+
+    def test_empty_candidates_raises(self):
+        with pytest.raises(IdentityError, match="None of the identity-claim values"):
+            _pick_role([], None)
+
+    def test_empty_candidates_raises_even_with_requested_role(self):
+        """No candidates → error regardless of requested_role (can't clamp
+        against an empty set)."""
+        with pytest.raises(IdentityError, match="None of the identity-claim values"):
+            _pick_role([], "anything")
+
+
+# ---------------------------------------------------------------------------
+# _get_db_role — end-to-end v2 wiring
+# ---------------------------------------------------------------------------
+
+class TestGetDbRoleV2:
+    """Exercise `_get_db_role` with v2 config (list claims, map file,
+    requested_role parameter)."""
+
+    @patch("yugabytedb_mcp_server.tools.get_access_token")
+    def test_cognito_access_token_groups_flow(self, mock_get_token):
+        """Realistic Cognito access-token workflow — DB-22192 unblocked."""
+        mock_get_token.return_value = _make_access_token(
+            {"sub": "abc", "cognito:groups": ["writer", "reader"]}
+        )
+        ctx = _make_ctx(identity_claim="cognito:groups", identity_map=None)
+        assert _get_db_role(ctx, requested_role="reader") == "reader"
+
+    @patch("yugabytedb_mcp_server.tools.get_access_token")
+    def test_cognito_groups_no_requested_role_defaults_first(self, mock_get_token):
+        mock_get_token.return_value = _make_access_token(
+            {"cognito:groups": ["writer", "reader"]}
+        )
+        ctx = _make_ctx(identity_claim="cognito:groups", identity_map=None)
+        assert _get_db_role(ctx) == "writer"
+
+    @patch("yugabytedb_mcp_server.tools.get_access_token")
+    def test_cognito_groups_requested_not_in_list_raises(self, mock_get_token):
+        mock_get_token.return_value = _make_access_token(
+            {"cognito:groups": ["writer", "reader"]}
+        )
+        ctx = _make_ctx(identity_claim="cognito:groups", identity_map=None)
+        with pytest.raises(IdentityError):
+            _get_db_role(ctx, requested_role="admin")
+
+    @patch("yugabytedb_mcp_server.tools.get_access_token")
+    def test_keycloak_realm_roles_flow(self, mock_get_token):
+        """Keycloak-style nested claim + literal map — YSQL parity example."""
+        mock_get_token.return_value = _make_access_token(
+            {"realm_access": {"roles": ["app-writer"]}}
+        )
+        entries = [_literal("default", "app-writer", "writer")]
+        ctx = _make_ctx(
+            identity_claim="realm_access.roles",
+            identity_map=entries,
+            identity_map_name="default",
+        )
+        assert _get_db_role(ctx) == "writer"
+
+    @patch("yugabytedb_mcp_server.tools.get_access_token")
+    def test_azure_group_guid_flow(self, mock_get_token):
+        """Azure AD GUID → readable role via regex map — closes DB-22174."""
+        mock_get_token.return_value = _make_access_token(
+            {"groups": ["a12d04b1-7463-8e23-94d2-8d71f17ab99b"]}
+        )
+        entries = [_regex("azure", r"^a12d04b1-.+", "reader")]
+        ctx = _make_ctx(
+            identity_claim="groups", identity_map=entries, identity_map_name="azure",
+        )
+        assert _get_db_role(ctx) == "reader"
+
+    @patch("yugabytedb_mcp_server.tools.get_access_token")
+    def test_map_filters_unmapped_list_values(self, mock_get_token):
+        """List claim with some values mapped, some not — unmapped values are
+        dropped, mapped values become the candidate list."""
+        mock_get_token.return_value = _make_access_token(
+            {"groups": ["known", "unknown-1", "also-known", "unknown-2"]}
+        )
+        entries = [
+            _literal("default", "known", "role_a"),
+            _literal("default", "also-known", "role_b"),
+        ]
+        ctx = _make_ctx(
+            identity_claim="groups", identity_map=entries, identity_map_name="default",
+        )
+        assert _get_db_role(ctx, requested_role="role_b") == "role_b"
+
+    @patch("yugabytedb_mcp_server.tools.get_access_token")
+    def test_map_all_values_unmapped_raises(self, mock_get_token):
+        """DB-22135: if the map has no entry for any of the claim's values,
+        raise instead of falling through to the raw claim."""
+        mock_get_token.return_value = _make_access_token(
+            {"groups": ["unknown-a", "unknown-b"]}
+        )
+        entries = [_literal("default", "different_value", "some_role")]
+        ctx = _make_ctx(
+            identity_claim="groups", identity_map=entries, identity_map_name="default",
+        )
+        with pytest.raises(IdentityError, match="None of the identity-claim values"):
+            _get_db_role(ctx)
+
+    @patch("yugabytedb_mcp_server.tools.get_access_token")
+    def test_map_with_scalar_claim(self, mock_get_token):
+        """Non-list claim (e.g. `email`) + map file — same lookup path."""
+        mock_get_token.return_value = _make_access_token(
+            {"email": "carol@yugabyte.com"}
+        )
+        entries = [_regex("default", r"^([a-z]+)@yugabyte\.com$", r"\1")]
+        ctx = _make_ctx(identity_claim="email", identity_map=entries)
+        assert _get_db_role(ctx) == "carol"
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed on malformed / missing map files
+# ---------------------------------------------------------------------------
+
+class TestFailClosed:
+    def test_map_file_nonexistent_raises_at_load(self, tmp_path):
+        with pytest.raises((FileNotFoundError, OSError)):
+            _load_identity_map(str(tmp_path / "does-not-exist.conf"))
+
+    def test_map_file_malformed_regex_raises_at_load(self, map_file_factory):
+        path = map_file_factory("map1 /[open_bracket_never_closed reader\n")
+        with pytest.raises(ValueError):
+            _load_identity_map(path)
+
+    def test_map_file_bad_field_count_raises_at_load(self, map_file_factory):
+        path = map_file_factory("map1  only_two_fields\n")
+        with pytest.raises(ValueError):
+            _load_identity_map(path)
+
+
+# ---------------------------------------------------------------------------
+# Security invariants
+# ---------------------------------------------------------------------------
+
+class TestSecurityInvariants:
+    """Invariants that must hold regardless of config — a violation would be
+    a security regression."""
+
+    def test_role_name_with_sql_injection_chars_passes_through(self):
+        """`_get_db_role` returns raw role names — SQL quoting happens at
+        the SET ROLE site via psycopg.sql.Identifier. Verify the string
+        makes it through unchanged so the Identifier layer can quote it."""
+        entries = [_literal("default", "evil", "writer'; DROP TABLE t--")]
+        with patch("yugabytedb_mcp_server.tools.get_access_token") as mock:
+            mock.return_value = _make_access_token({"sub": "evil"})
+            ctx = _make_ctx(identity_claim="sub", identity_map=entries)
+            # Whatever comes back from the map goes to psycopg's Identifier
+            # for quoting — this test asserts we don't accidentally strip or
+            # sanitize the value here (that would mask a downstream quoting
+            # regression).
+            assert _get_db_role(ctx) == "writer'; DROP TABLE t--"
+
+    @patch("yugabytedb_mcp_server.tools.get_access_token")
+    def test_empty_list_claim_raises_not_pool_fallback(self, mock_get_token):
+        """A token WITH a claim resolving to [] must raise IdentityError, not
+        fall back to pool credentials (that would be privilege escalation)."""
+        mock_get_token.return_value = _make_access_token({"groups": []})
+        ctx = _make_ctx(identity_claim="groups", identity_map=None)
+        with pytest.raises(IdentityError):
+            _get_db_role(ctx)
+
+    @patch("yugabytedb_mcp_server.tools.get_access_token")
+    def test_list_with_only_empty_strings_raises(self, mock_get_token):
+        """[""] filters to [] and raises — no ambiguous fallback."""
+        mock_get_token.return_value = _make_access_token({"groups": ["", ""]})
+        ctx = _make_ctx(identity_claim="groups", identity_map=None)
+        with pytest.raises(IdentityError):
+            _get_db_role(ctx)
+
+    @patch("yugabytedb_mcp_server.tools.get_access_token")
+    def test_requested_role_not_in_mapped_candidates_raises(self, mock_get_token):
+        """Even if `requested_role` matches a raw claim value, it must be
+        in the *mapped* candidate list — the map is the allowlist."""
+        mock_get_token.return_value = _make_access_token(
+            {"groups": ["raw_a", "raw_b"]}
+        )
+        entries = [
+            _literal("default", "raw_a", "mapped_a"),
+            _literal("default", "raw_b", "mapped_b"),
+        ]
+        ctx = _make_ctx(identity_claim="groups", identity_map=entries)
+        # `requested_role="raw_a"` is the RAW claim value; the candidate list
+        # contains the *mapped* values, so this must fail.
+        with pytest.raises(IdentityError):
+            _get_db_role(ctx, requested_role="raw_a")
+        # Sanity: the mapped value works.
+        assert _get_db_role(ctx, requested_role="mapped_a") == "mapped_a"

--- a/tests/test_identity_mapping.py
+++ b/tests/test_identity_mapping.py
@@ -206,7 +206,7 @@ def map_file_factory(tmp_path):
 class TestMapFileParser:
     def test_literal_entry(self, map_file_factory):
         path = map_file_factory("map1  user@yugabyte.com  user\n")
-        entries = _load_identity_map(path)
+        entries = _flatten(_load_identity_map(path))
         assert len(entries) == 1
         assert entries[0] == MapEntry(
             name="map1", pattern="user@yugabyte.com", role="user",
@@ -218,7 +218,7 @@ class TestMapFileParser:
         path = map_file_factory(
             "map2  /^(.*)@devadmincloudyugabyte\\.onmicrosoft\\.com$  \\1\n"
         )
-        entries = _load_identity_map(path)
+        entries = _flatten(_load_identity_map(path))
         assert entries[0].is_regex is True
         assert entries[0].compiled is not None
         assert entries[0].role == r"\1"
@@ -226,7 +226,7 @@ class TestMapFileParser:
     def test_role_to_role_entry(self, map_file_factory):
         """From the YSQL docs, verbatim: OIDC group name → PG role name."""
         path = map_file_factory("map1  OIDC.Test.Read  read_only_user\n")
-        entries = _load_identity_map(path)
+        entries = _flatten(_load_identity_map(path))
         assert entries[0].pattern == "OIDC.Test.Read"
         assert entries[0].role == "read_only_user"
         assert entries[0].is_regex is False
@@ -236,7 +236,7 @@ class TestMapFileParser:
         docs convention: leading `/` marks the pattern as regex; NO closing
         `/` (the rest of the field is the regex body verbatim)."""
         path = map_file_factory("azure  /^a12d04b1-.+  reader\n")
-        entries = _load_identity_map(path)
+        entries = _flatten(_load_identity_map(path))
         assert entries[0].compiled.fullmatch("a12d04b1-7463-8e23-94d2-8d71f17ab99b")
 
     def test_comments_and_blank_lines_ignored(self, map_file_factory):
@@ -248,19 +248,25 @@ class TestMapFileParser:
             "\n"
             "map1  bob    b_role  # trailing comment\n"
         )
-        entries = _load_identity_map(path)
+        entries = _flatten(_load_identity_map(path))
         assert len(entries) == 2
         assert entries[0].pattern == "alice"
         assert entries[1].pattern == "bob"
 
     def test_multiple_named_maps(self, map_file_factory):
+        """Entries are grouped by map_name at load time. Within a map, file
+        order is preserved (matters for match precedence in ``_apply_map``).
+        Across map names, order is not meaningful — a request only ever
+        consults one map at a time."""
         path = map_file_factory(
             "default  alice  a_role\n"
             "azure    bob    b_role\n"
             "default  carol  c_role\n"
         )
-        entries = _load_identity_map(path)
-        assert [e.name for e in entries] == ["default", "azure", "default"]
+        loaded = _load_identity_map(path)
+        assert set(loaded.keys()) == {"default", "azure"}
+        assert [e.pattern for e in loaded["default"]] == ["alice", "carol"]
+        assert [e.pattern for e in loaded["azure"]] == ["bob"]
 
     def test_malformed_regex_line_raises(self, map_file_factory):
         path = map_file_factory("map1  /[unterminated  reader\n")
@@ -278,12 +284,66 @@ class TestMapFileParser:
         embedded whitespace. Documents current behavior."""
         # split(None, 2) collapses trailing whitespace into field 3
         path = map_file_factory("map1 alice role_with_spaces\n")
-        entries = _load_identity_map(path)
+        entries = _flatten(_load_identity_map(path))
         assert entries[0].role == "role_with_spaces"
 
     def test_nonexistent_file_raises(self, tmp_path):
         with pytest.raises((FileNotFoundError, OSError)):
             _load_identity_map(str(tmp_path / "does-not-exist.conf"))
+
+    # ---- Negative-case fail-closed guarantees ----
+
+    def test_backreference_out_of_range_raises(self, map_file_factory):
+        """A ``\\N`` in db_role that references a capture group the pattern
+        doesn't have would raise ``re.error`` at request time under the old
+        code — bypassing the tool's ``except IdentityError`` and surfacing
+        as an unhandled 500. Validate the group count at LOAD time so the
+        server refuses to start."""
+        # Pattern has one group; role references \2.
+        path = map_file_factory(r"map1  /(.+)@corp\.com  \2" "\n")
+        with pytest.raises(ValueError, match=r"capture group \\2"):
+            _load_identity_map(path)
+
+    def test_hash_inside_pattern_is_not_a_comment(self, map_file_factory):
+        """A ``#`` mid-token (no preceding whitespace) is a literal ``#``,
+        not the start of a comment. Guards against silent truncation of a
+        pattern or role that legitimately contains ``#``."""
+        path = map_file_factory(r"map1  /user#\d+  reader" "\n")
+        entries = _flatten(_load_identity_map(path))
+        # Pattern preserved verbatim (leading `/` marks it as regex).
+        assert entries[0].pattern == r"/user#\d+"
+        # And it matches strings containing the literal `#`.
+        assert entries[0].compiled.fullmatch("user#42") is not None
+
+    def test_leading_hash_is_still_a_comment(self, map_file_factory):
+        """Sanity check: a line starting with ``#`` remains a comment."""
+        path = map_file_factory("# map1 alice role\nmap1 alice role\n")
+        entries = _flatten(_load_identity_map(path))
+        assert len(entries) == 1
+
+    def test_whitespace_preceded_hash_is_a_comment(self, map_file_factory):
+        """Sanity check: a ``#`` after whitespace still starts a comment
+        (matches pg_ident.conf convention)."""
+        path = map_file_factory("map1 alice role  # trailing comment\n")
+        entries = _flatten(_load_identity_map(path))
+        assert entries[0].role == "role"
+
+
+class TestApplyMapEmptyCapture:
+    """Empty-capture-group expansions must not surface as SET ROLE targets.
+    An empty role name would fail at the DB with a confusing error; treat
+    it as unmapped instead so the caller gets a clean IdentityError."""
+
+    def test_empty_capture_treated_as_unmapped(self):
+        # Pattern captures "" (the empty prefix before the fixed suffix).
+        entries = [_regex("default", r"(.*)@stub\.com", r"\1")]
+        # An input where the capture matches empty string:
+        assert _apply_map("@stub.com", _as_map(entries), "default") is None
+
+    def test_non_empty_capture_still_returns_role(self):
+        """Regression guard: non-empty captures still work."""
+        entries = [_regex("default", r"(.*)@stub\.com", r"\1")]
+        assert _apply_map("alice@stub.com", _as_map(entries), "default") == "alice"
 
 
 # ---------------------------------------------------------------------------
@@ -301,28 +361,47 @@ def _regex(name: str, pattern: str, role: str) -> MapEntry:
     )
 
 
+def _as_map(entries: list[MapEntry]) -> dict[str, list[MapEntry]]:
+    """Group a list of MapEntry into the Dict[map_name, entries] shape
+    _apply_map expects since the map is pre-indexed by name at load time."""
+    out: dict[str, list[MapEntry]] = {}
+    for e in entries:
+        out.setdefault(e.name, []).append(e)
+    return out
+
+
+def _flatten(loaded: dict[str, list[MapEntry]]) -> list[MapEntry]:
+    """Flatten the Dict[map_name, entries] shape returned by
+    _load_identity_map back into a list, preserving insertion order —
+    lets legacy loader tests keep asserting on a flat sequence."""
+    out: list[MapEntry] = []
+    for lst in loaded.values():
+        out.extend(lst)
+    return out
+
+
 class TestApplyMap:
     def test_literal_match(self):
         entries = [_literal("default", "bob@yugabyte.com", "writer")]
-        assert _apply_map("bob@yugabyte.com", entries, "default") == "writer"
+        assert _apply_map("bob@yugabyte.com", _as_map(entries), "default") == "writer"
 
     def test_regex_capture(self):
         entries = [_regex("default", r"^([a-z]+)@yugabyte\.com$", r"\1")]
-        assert _apply_map("carol@yugabyte.com", entries, "default") == "carol"
+        assert _apply_map("carol@yugabyte.com", _as_map(entries), "default") == "carol"
 
     def test_role_to_role_literal(self):
         entries = [_literal("default", "OIDC.Test.Read", "read_only_user")]
-        assert _apply_map("OIDC.Test.Read", entries, "default") == "read_only_user"
+        assert _apply_map("OIDC.Test.Read", _as_map(entries), "default") == "read_only_user"
 
     def test_azure_guid_regex(self):
         entries = [_regex("azure", r"^a12d04b1-.+", "reader")]
         assert _apply_map(
-            "a12d04b1-7463-8e23-94d2-8d71f17ab99b", entries, "azure",
+            "a12d04b1-7463-8e23-94d2-8d71f17ab99b", _as_map(entries), "azure",
         ) == "reader"
 
     def test_unmapped_returns_none(self):
         entries = [_literal("default", "alice", "a")]
-        assert _apply_map("someone-else", entries, "default") is None
+        assert _apply_map("someone-else", _as_map(entries), "default") is None
 
     def test_map_name_filter(self):
         """Entries under a different map_name must not match."""
@@ -330,19 +409,19 @@ class TestApplyMap:
             _literal("default", "alice", "wrong"),
             _literal("azure", "alice", "right"),
         ]
-        assert _apply_map("alice", entries, "azure") == "right"
+        assert _apply_map("alice", _as_map(entries), "azure") == "right"
 
     def test_map_name_isolation_no_leak(self):
         """A `default` entry must not match under `map_name="azure"`."""
         entries = [_literal("default", "alice", "a")]
-        assert _apply_map("alice", entries, "azure") is None
+        assert _apply_map("alice", _as_map(entries), "azure") is None
 
     def test_regex_is_anchored(self):
         """Regex uses fullmatch — a pattern without explicit anchors still
         requires the whole value to match, mirroring pg_ident.conf."""
         entries = [_regex("default", r"foo", "matched")]
-        assert _apply_map("foo", entries, "default") == "matched"
-        assert _apply_map("foobar", entries, "default") is None  # not anchored via search
+        assert _apply_map("foo", _as_map(entries), "default") == "matched"
+        assert _apply_map("foobar", _as_map(entries), "default") is None  # not anchored via search
 
     def test_first_match_wins(self):
         """When multiple entries under the same map_name could match, the
@@ -351,7 +430,7 @@ class TestApplyMap:
             _literal("default", "alice", "first"),
             _literal("default", "alice", "second"),
         ]
-        assert _apply_map("alice", entries, "default") == "first"
+        assert _apply_map("alice", _as_map(entries), "default") == "first"
 
 
 # ---------------------------------------------------------------------------
@@ -365,11 +444,17 @@ class TestPickRole:
     def test_single_candidate_auto_pick(self):
         assert _pick_role(["writer"], None) == "writer"
 
-    def test_single_candidate_ignores_requested_role(self):
-        """One candidate is always picked, even if requested_role is different
-        (we could raise here — but the ergonomic choice is auto-pick since
-        the caller had exactly one option)."""
-        assert _pick_role(["writer"], "reader") == "writer"
+    def test_single_candidate_mismatch_raises(self):
+        """A requested_role that doesn't match the sole candidate is a
+        misconfiguration, not a hint to silently promote the caller. The
+        agent's declared intent must be honored or refused — never
+        silently overridden."""
+        with pytest.raises(IdentityError, match="not in the caller's identity-claim"):
+            _pick_role(["writer"], "reader")
+
+    def test_single_candidate_matching_request_returns_it(self):
+        """When requested_role matches the sole candidate, return it."""
+        assert _pick_role(["writer"], "writer") == "writer"
 
     def test_multi_candidate_requested_role_in_list(self):
         assert _pick_role(["writer", "reader"], "reader") == "reader"
@@ -378,10 +463,12 @@ class TestPickRole:
         with pytest.raises(IdentityError, match="not in the caller's identity-claim"):
             _pick_role(["writer", "reader"], "admin")
 
-    def test_multi_candidate_no_request_defaults_to_first(self, caplog):
-        with caplog.at_level("WARNING"):
-            assert _pick_role(["writer", "reader"], None) == "writer"
-        assert any("multiple roles" in r.message for r in caplog.records)
+    def test_multi_candidate_no_request_raises(self):
+        """Ambiguity is never silently resolved. The server refuses to pick
+        arbitrarily to avoid accidentally granting the more-privileged
+        role. The agent must pass requested_role to disambiguate."""
+        with pytest.raises(IdentityError, match="multiple roles"):
+            _pick_role(["writer", "reader"], None)
 
     def test_empty_candidates_raises(self):
         with pytest.raises(IdentityError, match="None of the identity-claim values"):
@@ -412,12 +499,17 @@ class TestGetDbRoleV2:
         assert _get_db_role(ctx, requested_role="reader") == "reader"
 
     @patch("yugabytedb_mcp_server.tools.get_access_token")
-    def test_cognito_groups_no_requested_role_defaults_first(self, mock_get_token):
+    def test_cognito_groups_no_requested_role_raises(self, mock_get_token):
+        """Multiple candidates + no requested_role → IdentityError. The
+        server refuses to default to the first entry (which would be the
+        IdP-controlled ordering) to avoid granting the more-privileged
+        role by accident."""
         mock_get_token.return_value = _make_access_token(
             {"cognito:groups": ["writer", "reader"]}
         )
         ctx = _make_ctx(identity_claim="cognito:groups", identity_map=None)
-        assert _get_db_role(ctx) == "writer"
+        with pytest.raises(IdentityError, match="multiple roles"):
+            _get_db_role(ctx)
 
     @patch("yugabytedb_mcp_server.tools.get_access_token")
     def test_cognito_groups_requested_not_in_list_raises(self, mock_get_token):
@@ -437,7 +529,7 @@ class TestGetDbRoleV2:
         entries = [_literal("default", "app-writer", "writer")]
         ctx = _make_ctx(
             identity_claim="realm_access.roles",
-            identity_map=entries,
+            identity_map=_as_map(entries),
             identity_map_name="default",
         )
         assert _get_db_role(ctx) == "writer"
@@ -450,7 +542,7 @@ class TestGetDbRoleV2:
         )
         entries = [_regex("azure", r"^a12d04b1-.+", "reader")]
         ctx = _make_ctx(
-            identity_claim="groups", identity_map=entries, identity_map_name="azure",
+            identity_claim="groups", identity_map=_as_map(entries), identity_map_name="azure",
         )
         assert _get_db_role(ctx) == "reader"
 
@@ -466,7 +558,7 @@ class TestGetDbRoleV2:
             _literal("default", "also-known", "role_b"),
         ]
         ctx = _make_ctx(
-            identity_claim="groups", identity_map=entries, identity_map_name="default",
+            identity_claim="groups", identity_map=_as_map(entries), identity_map_name="default",
         )
         assert _get_db_role(ctx, requested_role="role_b") == "role_b"
 
@@ -479,7 +571,7 @@ class TestGetDbRoleV2:
         )
         entries = [_literal("default", "different_value", "some_role")]
         ctx = _make_ctx(
-            identity_claim="groups", identity_map=entries, identity_map_name="default",
+            identity_claim="groups", identity_map=_as_map(entries), identity_map_name="default",
         )
         with pytest.raises(IdentityError, match="None of the identity-claim values"):
             _get_db_role(ctx)
@@ -491,7 +583,7 @@ class TestGetDbRoleV2:
             {"email": "carol@yugabyte.com"}
         )
         entries = [_regex("default", r"^([a-z]+)@yugabyte\.com$", r"\1")]
-        ctx = _make_ctx(identity_claim="email", identity_map=entries)
+        ctx = _make_ctx(identity_claim="email", identity_map=_as_map(entries))
         assert _get_db_role(ctx) == "carol"
 
 
@@ -530,7 +622,7 @@ class TestSecurityInvariants:
         entries = [_literal("default", "evil", "writer'; DROP TABLE t--")]
         with patch("yugabytedb_mcp_server.tools.get_access_token") as mock:
             mock.return_value = _make_access_token({"sub": "evil"})
-            ctx = _make_ctx(identity_claim="sub", identity_map=entries)
+            ctx = _make_ctx(identity_claim="sub", identity_map=_as_map(entries))
             # Whatever comes back from the map goes to psycopg's Identifier
             # for quoting — this test asserts we don't accidentally strip or
             # sanitize the value here (that would mask a downstream quoting
@@ -565,7 +657,7 @@ class TestSecurityInvariants:
             _literal("default", "raw_a", "mapped_a"),
             _literal("default", "raw_b", "mapped_b"),
         ]
-        ctx = _make_ctx(identity_claim="groups", identity_map=entries)
+        ctx = _make_ctx(identity_claim="groups", identity_map=_as_map(entries))
         # `requested_role="raw_a"` is the RAW claim value; the candidate list
         # contains the *mapped* values, so this must fail.
         with pytest.raises(IdentityError):


### PR DESCRIPTION
## Summary

Ships **PR #2** of the MCP Server v2 audit release plan. Ports YSQL's native OIDC → PG role mapping to the MCP server and closes the JWT audience / `token_use` gap. **Four tickets closed** — two Medium in-scope, two Low pulled up because they fall out for free with the v2 mapping design.

### Tickets closed

| Ticket | Priority | How this PR closes it |
|---|---|---|
| **[DB-22135](https://yugabyte.atlassian.net/browse/DB-22135)** | Medium | Map file is the allowlist — a claim value with no matching entry raises `IdentityError` pre-SQL. The superuser-pool + arbitrary-role attack path is designed out; startup now refuses a list-claim configuration without a map file so an operator can't accidentally deploy the unbounded-role-space setup. `psycopg.sql.Identifier` quoting was already in place for the role name. |
| **[DB-22174](https://yugabyte.atlassian.net/browse/DB-22174)** | Low → pulled up | Map file makes each `claim_value → role` explicit. `bob@company-a.com` and `bob@company-b.com` are two rows (or one is rejected) — no `strip_domain` collision. Operators can also skip `strip_domain` entirely by picking `sub` / `preferred_username`. |
| **[DB-22192](https://yugabyte.atlassian.net/browse/DB-22192)** | Low → pulled up | Operators can pick claims present in Cognito access tokens (`cognito:groups`, `sub`, `custom:*` via Lambda). Removes the "email → ID-token-only" dependency, unblocking DB-22136's full fix. |
| **[DB-22136](https://yugabyte.atlassian.net/browse/DB-22136)** | Medium | Audience validation always on (both Cognito and OIDC paths). `token_use=access` enforcement opt-in via `YB_MCP_REQUIRE_ACCESS_TOKEN=true` — safe default preserves backward compat; documented migration path in `OIDC.md`. |

### Design north star

Parity with YSQL's native OIDC → PG role mapping (`ysql_hba_conf_csv` + `ysql_ident_conf_csv` + `matching_claim_key`). Reference: [YugabyteDB Anywhere OIDC docs (Azure AD)](https://docs.yugabyte.com/stable/yugabyte-platform/security/authentication/oidc-authentication-aad/).

### What changed

**Config surface (v2 additions):**

| Env var | Purpose |
|---|---|
| `YB_MCP_IDENTITY_CLAIM` (extended) | Now accepts dotted paths (`realm_access.roles`, `cognito:groups`). |
| `YB_MCP_IDENTITY_MAP` | Path to a `pg_ident.conf`-style map file. Fail-closed on malformed. |
| `YB_MCP_IDENTITY_MAP_NAME` | Which named map inside the file to apply (default: `default`). |
| `YB_MCP_REQUIRE_ACCESS_TOKEN` | Cognito-only. Reject `token_use != "access"` when `true`. Default `false`. |

**Tool interface:** all three DB tools (`summarize_database`, `run_read_only_query`, `run_write_query`) gain an optional `requested_role: str | None = None` parameter. When the JWT's identity claim resolves to more than one role, the agent uses `requested_role` to pick one — the server clamps against the JWT's mapped candidate list so the agent can never pick a role the token doesn't allow.

### Behavior deltas from v1

Backward-compat has narrow, deliberate exceptions — each closes a soft security gap the v1 defaults left open. Existing deployments that don't hit these cases are unaffected.

| Change | Was in v1 | Is now |
|---|---|---|
| Multi-candidate claim + no `requested_role` | Silent default to `candidates[0]` with a WARNING (IdP-controlled ordering picks the winner) | `IdentityError`. Ambiguity must be resolved explicitly by the agent. |
| Single-candidate claim + mismatched `requested_role` | Server silently auto-picked the sole candidate, ignoring the mismatch | `IdentityError` on any mismatch, regardless of candidate count. |
| `YB_MCP_IDENTITY_CLAIM` list-shaped (`cognito:groups`, `realm_access.roles`, dotted paths) + `YB_MCP_IDENTITY_MAP` unset | Silent warning at startup; every group name became a `SET ROLE` target verbatim (no allowlist) | Server refuses to start with a `RuntimeError`. |
| Map file with an out-of-range `\N` backreference in `db_role` | Silent at load; raised uncaught `re.error` at request time (500) | Rejected at load time with a clear `ValueError`. |
| Regex map entry whose capture group expands to `""` | Yielded `SET ROLE ""` (opaque DB error) | Treated as unmapped; standard "unmapped value" error path runs. |
| `#` mid-token in a pattern/role field | Truncated as if a comment | Preserved as a literal character; `#` only starts a comment at line-start or after whitespace. |

**Fully backward-compat**: with `YB_MCP_IDENTITY_MAP` unset and `YB_MCP_IDENTITY_CLAIM` at its scalar default (`email`), and `YB_MCP_REQUIRE_ACCESS_TOKEN` unset, behavior is identical to v1.

### Docs

New `OIDC.md` at repo root — 698 lines, single source of truth for OIDC / identity mapping. Covers provider setup, env-var reference, the 6-step mapping pipeline, map-file spec, 5 worked examples (Cognito with `email`; Cognito with `cognito:groups`; Keycloak with `realm_access.roles`; Azure AD with GUID `groups`; generic OIDC with custom claim), security guidance, migration checklist, troubleshooting, and a YSQL-parity reference.

`README.md` trimmed accordingly — three OIDC sections (config-table entries, HTTP-mode setup walkthrough, per-user SET ROLE section) collapsed to pointers at `OIDC.md`. Net: 378 → 308 lines.

### Examples

New sibling to `examples/oidc-auth/`:

- **`examples/oidc-auth-mapping/`** — a runnable Keycloak-based tutorial that exercises the v2 additions end-to-end: dotted-path claim (`realm_access.roles`), a map file, three demo users (single-role writer, single-role reader, dual-role that must pass `requested_role`), and an audience-mapper on the client scope so the server's `OIDC_AUDIENCE` check has something to validate. Coexists with the sibling tutorial on separate ports (Keycloak :18081, callback :9877) so both can run at the same time.

The existing `examples/oidc-auth/` is untouched and still demonstrates the simplest v1-shape flow (`email` claim + `strip_domain`).

### Test coverage

**71 new unit tests** across two files. Total non-integration suite: **280 tests, all passing**.

- `tests/test_identity_mapping.py` — 69 tests (up from v1's 12):
  - `TestApplyTransform` (5) + `TestGetDbRole` (7) — v1 backward-compat regression harness, preserved verbatim.
  - `TestExtractClaim` (9), `TestMapFileParser` (14), `TestApplyMap` (9), `TestApplyMapEmptyCapture` (2), `TestPickRole` (8), `TestGetDbRoleV2` (8), `TestFailClosed` (3), `TestSecurityInvariants` (4).
- `tests/test_auth.py` — 20 tests (up from 6): audience mismatch/match on raw `JWTVerifier`, `_create_cognito` wires `client_id` as expected audience, `_create_oidc` forwards `OIDC_AUDIENCE`, missing `OIDC_AUDIENCE` logs WARNING, ID-token accept+WARN vs reject (opt-in), access-token accepted, refresh-token rejected, plus the class-based factory tests.

**Security invariants tested:**
- Role names go through `psycopg.sql.Identifier` — no injection via role name.
- `IdentityError` on empty list, missing key, or unmapped value — no fallback to pool credentials.
- `IdentityError` on multi-candidate + missing `requested_role` (fail-closed on ambiguity).
- `IdentityError` on `requested_role` not in the mapped candidate list (agent can't smuggle raw claim values).
- Malformed map file at startup → server refuses to start (fail-closed).
- List-claim configured without a map → server refuses to start (fail-closed).
- Map with an out-of-range `\N` backreference → refused at load (not surfaced as request-time 500).
- Regex capture that matches `""` → treated as unmapped, not `SET ROLE ""`.

### Sequencing

- Merged onto latest `main` (`5ea284a`) — includes the audit's PR #1 ([#9, merged 2026-07-24](https://github.com/yugabyte/yugabytedb-mcp-server/pull/9)). Merge resolved one textual conflict in `tools.py` (both `import math` and `import re` needed) and one logical conflict where main's new `test_registration.py` constructs `ServerConfig` and needed to pass the v2 fields we added.

### What's NOT in this PR (deferred)

- **CI-driven integration tests** for the SET ROLE path. The example under `examples/oidc-auth-mapping/` gives a runnable end-to-end harness (Keycloak + YB + demo client) that was used to validate every case listed in "Behavior deltas from v1" against a live stack — but adding this to CI needs a new harness (Docker networking, Keycloak boot time, YB seeding) which is v2.1 scope. Manual smoke-run instructions are in the example's README.
- **Follow-up hardening tickets** (DB-22133, DB-22175, DB-22187, etc.) — per the audit release plan, deferred to the v2.1 hardening release.

## Test plan

- [x] `uv run pytest tests/test_identity_mapping.py -v` — 69 tests
- [x] `uv run pytest tests/test_auth.py -v` — 20 tests
- [x] `uv run pytest tests/ --ignore=tests/test_integration_*.py -q` — 280 tests
- [x] Manual end-to-end against local Keycloak (`examples/oidc-auth-mapping/`) for all 5 mapping cases: single-role writer/reader, dual-role with `requested_role=writer`, dual-role with `requested_role=reader`, dual-role with no `requested_role` (now `IdentityError`).
- [x] Verify DB-22135 repro: superuser pool + no `YB_MCP_IDENTITY_MAP` → WARNING logged (or startup-refused for list-claim configs); setting a limited-entry map → `IdentityError` on unmapped claim value.
- [x] Verify DB-22174 repro: two identities with same email local-part, different domains → distinct roles (or one rejected) via map.
- [x] Verify DB-22192 repro: Cognito access token with `cognito:groups` + `YB_MCP_IDENTITY_CLAIM=cognito:groups` → mapping works without email.
- [x] Verify DB-22136 repro: token minted for another app client in the same pool → 401; `token_use=id` with `YB_MCP_REQUIRE_ACCESS_TOKEN=true` → 401.
