### PR TITLE
Guardrail: block INSERT ... SELECT and CREATE/ALTER FUNCTION/PROCEDURE on write tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,112 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+_(No unreleased changes.)_
+
+## [2.0.0] - Unreleased
+
+### Added
+
+- **OIDC v2 identity mapping + JWT audience validation (#10).** Maps
+  OIDC access-token claims to PostgreSQL roles via a `pg_ident.conf`-style
+  identity map. New env vars: `YB_MCP_IDENTITY_CLAIM`,
+  `YB_MCP_IDENTITY_TRANSFORM`, `YB_MCP_IDENTITY_MAP`,
+  `YB_MCP_IDENTITY_MAP_NAME`. `SET ROLE` is issued on each connection
+  checkout using the mapped role, and connections are returned to the
+  pool via `RESET ROLE` + `DISCARD ALL`. JWT audience is validated
+  against the configured resource server.
+- **Keycloak OIDC → Postgres role mapping tutorial (#8).** New example
+  under `examples/oidc-auth-mapping/keycloak/` — realm export, docker
+  compose, and step-by-step README covering end-to-end auth to YugabyteDB.
+
+### Changed
+
+- **`run_write_query` is opt-in (#7).** The write tool is no longer
+  registered by default. Set `YB_MCP_ENABLE_WRITE_QUERY=true` (or
+  `--enable-write-query`) to expose it. The read tools remain on by
+  default.
+- **`run_read_only_query` response shape (#9).** Now returns
+  `{"columns": [...], "rows": [[...], ...]}` instead of a list of dicts.
+  Duplicate output column names (e.g. `SELECT * FROM a, b` where both
+  have `id`) previously collapsed silently; the new shape preserves
+  every column.
+
+### Security
+
+- **Unified SQL guardrail across read and write tools (#9).** A single
+  parsed-statement validator now runs on both `run_read_only_query` and
+  `run_write_query`. Highlights:
+  - Read tool blocks dangerous functions and catalog surfaces that can
+    read files, execute shell, or reach across sessions
+    (`pg_read_file`, `pg_read_binary_file`, `pg_write_file`, `pg_ls_dir`,
+    `dblink*`, `lo_import`, `set_config`, `pg_sleep`, etc.) plus
+    `SET search_path`.
+  - Multi-statement input is rejected on both tools.
+  - Optional `WHERE`-clause requirement on `UPDATE`/`DELETE` via
+    `YB_MCP_REQUIRE_WHERE_ON_UPDATE` / `..._ON_DELETE`.
+  - `YB_MCP_MAX_INSERT_ROWS` caps `INSERT ... VALUES` row counts on the
+    write tool.
+  - Statement timeout applied to reads to bound expensive queries.
+- **Write-tool guardrail: reject additional unbounded write shapes.**
+  `YB_MCP_MAX_INSERT_ROWS` only caps `INSERT ... VALUES`. The following
+  shapes bypassed the cap and are now rejected outright on the write
+  path:
+  - `INSERT ... SELECT ...` (unbounded row copy).
+  - `CREATE FUNCTION`, `CREATE PROCEDURE`, `ALTER FUNCTION`, `ALTER PROCEDURE`
+    (can execute arbitrary PL code and, with `SECURITY DEFINER`, run as the
+    function owner).
+
+  Safe shapes are unaffected: `INSERT ... VALUES (...)` (subject to
+  `YB_MCP_MAX_INSERT_ROWS`) and `INSERT ... DEFAULT VALUES` continue to
+  work, as do `CREATE TABLE ... AS SELECT` and `SELECT ... INTO` (also
+  unbounded copies, but left allowed for their common
+  materialize-a-snapshot use case).
+
+## [2.0.0rc2] - 2026-05-25
+
+### Fixed
+
+- Entry point for `uvx yugabytedb-mcp-server` invocation.
+
+## [2.0.0rc1] - 2026-05-25
+
+### Added
+
+- **Claude Connector Directory submission readiness (#6).** Package renamed
+  to `yugabytedb-mcp-server` on PyPI. Reworked packaging, metadata, and
+  entry points so the server can be installed and launched by Claude
+  Connector Directory clients.
+
+## [1.0.2] - 2025-08-05
+
+### Added
+
+- **AWS Secrets Manager–based SSL root certificate support (#5).** New env
+  vars `YB_AWS_SSL_ROOT_CERT_SECRET_ARN`,
+  `YB_AWS_SSL_ROOT_CERT_SECRET_REGION`, and
+  `YB_AWS_SSL_ROOT_CERT_SECRET_KEY` let the server fetch a YugabyteDB CA
+  bundle from Secrets Manager at startup and materialize it for the
+  psycopg driver.
+- Groundwork for Claude Connector Directory submission.
+
+### Fixed
+
+- **JSON-RPC handling (#4).** Fixes a JSON-RPC framing bug that surfaced
+  in some MCP client interactions.
+
+---
+
+Older releases (v1.0.0, v1.0.1) predate the public PyPI listing and are
+not enumerated here — see git tags for the source snapshots.
+
+[Unreleased]: https://github.com/yugabyte/yugabytedb-mcp-server/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/yugabyte/yugabytedb-mcp-server/compare/v2.0.0rc2...HEAD
+[2.0.0rc2]: https://github.com/yugabyte/yugabytedb-mcp-server/compare/v2.0.0rc1...v2.0.0rc2
+[2.0.0rc1]: https://github.com/yugabyte/yugabytedb-mcp-server/compare/v1.0.2...v2.0.0rc1
+[1.0.2]: https://github.com/yugabyte/yugabytedb-mcp-server/releases/tag/v1.0.2

--- a/README.md
+++ b/README.md
@@ -161,14 +161,18 @@ The following statement classes are rejected before execution:
 
 - `DROP DATABASE/SCHEMA`, `ALTER DATABASE`, `CREATE DATABASE`
 - Role/privilege ops: `GRANT`, `REVOKE`, `CREATE/ALTER/DROP ROLE`, `CREATE/ALTER/DROP USER`
+- Stored code that can run under the owner (`SECURITY DEFINER`): `CREATE FUNCTION`, `CREATE PROCEDURE`, `ALTER FUNCTION`, `ALTER PROCEDURE`
 - Filesystem / code execution: `COPY TO/FROM`, `LOAD`, anonymous `DO $$ … $$`, `CREATE EXTENSION`
 - Server config: `ALTER SYSTEM`, `RESET ALL`
 - Dangerous built-ins: `pg_sleep`, `pg_read_file`, `pg_write_file`, `lo_import`, `lo_export`, `dblink`
 - Schema isolation: `SET search_path`, `CREATE SCHEMA`
 - Multi-statement queries (anything with a separator semicolon)
 - `psql` meta-commands (`\c`, `\d`, `\!`)
+- `INSERT … SELECT` (unbounded row source; `YB_MCP_MAX_INSERT_ROWS` only caps `INSERT … VALUES`)
 - INSERT … VALUES over `YB_MCP_MAX_INSERT_ROWS`
 - Optionally UPDATE / DELETE without a WHERE clause
+
+`CREATE TABLE … AS SELECT` and `SELECT … INTO` are structurally similar unbounded row copies but are intentionally **allowed** — they're the common way to materialize a snapshot from a query.
 
 This list is best-effort, not exhaustive. `destructiveHint: true` is the second line of defense.
 

--- a/src/yugabytedb_mcp_server/guardrails.py
+++ b/src/yugabytedb_mcp_server/guardrails.py
@@ -80,6 +80,13 @@ _BLOCKED_KEYWORD_PAIRS: dict[tuple[str, str], str] = {
     ("ALTER", "SYSTEM"): "ALTER SYSTEM is not allowed",
     ("RESET", "ALL"): "RESET ALL is not allowed",
     ("CREATE", "SCHEMA"): "CREATE SCHEMA is not allowed",
+    # DB-22131 remainder: CREATE FUNCTION / PROCEDURE can run arbitrary
+    # PL code and, with SECURITY DEFINER, escalate to the owner's role.
+    # No legitimate MCP-tool use case; block outright on the write path.
+    ("CREATE", "FUNCTION"): "CREATE FUNCTION is not allowed",
+    ("CREATE", "PROCEDURE"): "CREATE PROCEDURE is not allowed",
+    ("ALTER", "FUNCTION"): "ALTER FUNCTION is not allowed",
+    ("ALTER", "PROCEDURE"): "ALTER PROCEDURE is not allowed",
 }
 
 
@@ -263,6 +270,24 @@ def _count_values_rows(sql: str) -> int | None:
     return None
 
 
+def _stmt_has_select_source(stmt) -> bool:
+    """True if the parsed statement contains a DML ``SELECT`` token.
+
+    Used by the write-path INSERT check to distinguish
+    ``INSERT … SELECT`` (unbounded, blocked) from ``INSERT … VALUES``
+    and ``INSERT … DEFAULT VALUES`` (both static / trivially bounded).
+
+    ``flatten()`` walks the whole token tree so nested subqueries (WITH,
+    parenthesised SELECTs) are caught too. String literals containing
+    the word "SELECT" are tokenised as ``Token.Literal.String.Single``,
+    not ``Token.Keyword.DML``, so they cannot false-positive.
+    """
+    for tok in stmt.flatten():
+        if tok.ttype in T.Keyword.DML and tok.normalized.upper() == "SELECT":
+            return True
+    return False
+
+
 def _has_top_level_where(sql: str) -> bool:
     """Return True if a `Where` group exists at the top level of the statement.
 
@@ -344,12 +369,27 @@ def validate_query(sql: str, config: GuardrailConfig, read_only: bool) -> None:
 
     if stmt_type == "INSERT":
         row_count = _count_values_rows(cleaned)
-        if row_count is not None and row_count > config.max_insert_rows:
+        if row_count is not None:
+            if row_count > config.max_insert_rows:
+                raise QueryBlockedError(
+                    f"INSERT contains {row_count} rows, which exceeds the "
+                    f"maximum of {config.max_insert_rows} rows per statement. "
+                    f"Please split into smaller batches."
+                )
+        elif _stmt_has_select_source(stmt):
+            # `INSERT … SELECT` produces an unbounded number of rows from
+            # a subquery, so `max_insert_rows` (which counts VALUES tuples
+            # statically) can't enforce the cap. Reject on the write path;
+            # users can restructure to `INSERT … VALUES (…), (…)` or split
+            # into batches.
             raise QueryBlockedError(
-                f"INSERT contains {row_count} rows, which exceeds the "
-                f"maximum of {config.max_insert_rows} rows per statement. "
-                f"Please split into smaller batches."
+                "INSERT … SELECT is not allowed on the write tool "
+                "(YB_MCP_MAX_INSERT_ROWS only caps INSERT … VALUES). "
+                "Use INSERT … VALUES with an explicit row list, or split "
+                "the source query into batches."
             )
+        # `INSERT … DEFAULT VALUES` is a single-row insert with no VALUES
+        # tuple and no SELECT source — trivially within the cap, allow.
 
     if config.require_where_on_update and stmt_type == "UPDATE":
         if not _has_top_level_where(cleaned):

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -48,7 +48,7 @@ def strict_cfg():
     "CREATE TABLE t (id INT)",
     "ALTER TABLE t ADD COLUMN c TEXT",
     "DROP TABLE t",                       # Only DROP DATABASE/SCHEMA blocked
-    "INSERT INTO t SELECT * FROM s",      # INSERT ... SELECT has no row-count enforcement
+    "INSERT INTO t DEFAULT VALUES",       # Single-row default insert, no VALUES tuple
 ])
 def test_allows(sql, cfg):
     validate_query(sql, cfg, read_only=False)  # raises if blocked
@@ -226,9 +226,46 @@ def test_bulk_insert_over_limit(cfg):
     assert "exceeds the maximum" in str(exc.value)
 
 
-def test_bulk_insert_select_no_limit(cfg):
-    # INSERT ... SELECT has no VALUES, so row-count limit does not apply
-    validate_query("INSERT INTO t SELECT * FROM huge_table", cfg, read_only=False)
+def test_insert_select_rejected(cfg):
+    """DB-22131 remainder: ``INSERT … SELECT`` is an unbounded row source
+    (max_insert_rows only counts VALUES tuples statically), so it must
+    be blocked on the write path — otherwise
+    ``INSERT INTO t SELECT generate_series(1, 1_000_000)`` writes a
+    million rows despite max_insert_rows=cfg.max_insert_rows."""
+    with pytest.raises(QueryBlockedError) as exc:
+        validate_query("INSERT INTO t SELECT * FROM huge_table", cfg, read_only=False)
+    assert "INSERT" in str(exc.value) and "SELECT" in str(exc.value)
+
+
+def test_insert_select_generate_series_rejected(cfg):
+    """Vishal's exact repro from the ticket."""
+    with pytest.raises(QueryBlockedError):
+        validate_query(
+            "INSERT INTO t SELECT generate_series(1, 50)", cfg, read_only=False,
+        )
+
+
+def test_insert_with_cte_select_rejected(cfg):
+    """A CTE that hides the SELECT source is still an unbounded copy —
+    the flattened-token walker catches nested SELECTs."""
+    with pytest.raises(QueryBlockedError):
+        validate_query(
+            "WITH src AS (SELECT id FROM other) INSERT INTO t SELECT * FROM src",
+            cfg, read_only=False,
+        )
+
+
+def test_insert_default_values_still_allowed(cfg):
+    """Regression: ``INSERT … DEFAULT VALUES`` inserts one row with all
+    column defaults — bounded and safe. Must not be caught by the new
+    INSERT-…-SELECT rejection."""
+    validate_query("INSERT INTO t DEFAULT VALUES", cfg, read_only=False)
+
+
+def test_insert_values_still_allowed(cfg):
+    """Regression: the vanilla ``INSERT … VALUES (…)`` path is unaffected
+    by the new INSERT-…-SELECT check."""
+    validate_query("INSERT INTO t (id) VALUES (1), (2), (3)", cfg, read_only=False)
 
 
 # ---------------------------------------------------------------------------
@@ -253,6 +290,84 @@ def test_delete_without_where_blocked_when_strict(strict_cfg):
 
 def test_delete_with_where_allowed_when_strict(strict_cfg):
     validate_query("DELETE FROM t WHERE id = 1", strict_cfg, read_only=False)
+
+
+# ---------------------------------------------------------------------------
+# CREATE FUNCTION / CREATE PROCEDURE — arbitrary code + privilege escalation
+# ---------------------------------------------------------------------------
+
+def test_create_function_rejected(cfg):
+    """CREATE FUNCTION runs arbitrary PL code and can grant privileges via
+    SECURITY DEFINER — no legitimate MCP-tool use case."""
+    with pytest.raises(QueryBlockedError) as exc:
+        validate_query(
+            "CREATE FUNCTION f() RETURNS int LANGUAGE SQL AS $$ SELECT 1 $$",
+            cfg, read_only=False,
+        )
+    assert "CREATE FUNCTION" in str(exc.value)
+
+
+def test_create_function_security_definer_rejected(cfg):
+    """The SECURITY DEFINER variant is the most dangerous form —
+    privilege escalation to function owner. Same blocklist entry catches
+    it."""
+    with pytest.raises(QueryBlockedError):
+        validate_query(
+            "CREATE FUNCTION f() RETURNS int "
+            "SECURITY DEFINER LANGUAGE SQL AS $$ SELECT 1 $$",
+            cfg, read_only=False,
+        )
+
+
+def test_create_procedure_rejected(cfg):
+    """CREATE PROCEDURE is CREATE FUNCTION's sibling — same class of
+    concern."""
+    with pytest.raises(QueryBlockedError):
+        validate_query(
+            "CREATE PROCEDURE p() LANGUAGE plpgsql AS $$ BEGIN END $$",
+            cfg, read_only=False,
+        )
+
+
+def test_alter_function_rejected(cfg):
+    """ALTER FUNCTION can flip SECURITY DEFINER on an existing function —
+    same escalation risk as CREATE."""
+    with pytest.raises(QueryBlockedError):
+        validate_query(
+            "ALTER FUNCTION f() SECURITY DEFINER", cfg, read_only=False,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Bulk-copy shapes intentionally left ALLOWED
+# ---------------------------------------------------------------------------
+# `CREATE TABLE … AS SELECT` and `SELECT … INTO` are unbounded row copies
+# in the same family as `INSERT … SELECT`, but the team chose to allow them
+# — they're commonly used to materialize a snapshot from an existing query
+# and blocking them broke a valid workflow. These tests pin that choice so
+# a future guardrail expansion doesn't silently regress it.
+
+def test_create_table_as_select_allowed(cfg):
+    validate_query(
+        "CREATE TABLE snap AS SELECT * FROM src", cfg, read_only=False,
+    )
+
+
+def test_create_unlogged_table_as_select_allowed(cfg):
+    validate_query(
+        "CREATE UNLOGGED TABLE snap AS SELECT * FROM src",
+        cfg, read_only=False,
+    )
+
+
+def test_select_into_allowed(cfg):
+    validate_query("SELECT * INTO snap FROM src", cfg, read_only=False)
+
+
+def test_create_table_plain_still_allowed(cfg):
+    """Regression: ``CREATE TABLE t (col int)`` (no AS SELECT) is a
+    bounded DDL statement — no rows copied, must not be blocked."""
+    validate_query("CREATE TABLE t (id int, name text)", cfg, read_only=False)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The existing `YB_MCP_MAX_INSERT_ROWS` cap only counted `VALUES` tuples statically, so `INSERT ... SELECT` bypassed it (unbounded row source from a subquery). `CREATE FUNCTION` / `CREATE PROCEDURE` (and their `ALTER` variants) also had no block on the write tool, allowing arbitrary PL code — with `SECURITY DEFINER`, running as the function owner.

This PR closes both gaps and pins the team's decision to leave `CREATE TABLE ... AS SELECT` and `SELECT ... INTO` **allowed**.

## Changes

- `src/yugabytedb_mcp_server/guardrails.py`:
  - New helper `_stmt_has_select_source()` — walks the flattened token tree for a `Keyword.DML` `SELECT`. Catches CTE-nested subqueries (`WITH … INSERT INTO t SELECT …`) too.
  - Write-path `INSERT` check now also rejects when `_count_values_rows` returns `None` (no VALUES tuple) and a SELECT source is present. `INSERT ... DEFAULT VALUES` (no VALUES tuple, no SELECT source) is still allowed.
  - Four new entries in `_BLOCKED_KEYWORD_PAIRS`: `CREATE FUNCTION`, `CREATE PROCEDURE`, `ALTER FUNCTION`, `ALTER PROCEDURE`.
- `tests/test_guardrails.py`: 13 new tests (5 for `INSERT ... SELECT`, 4 for `CREATE`/`ALTER FUNCTION`/`PROCEDURE`, 4 pinning `CREATE TABLE ... AS SELECT` / `SELECT ... INTO` / plain `CREATE TABLE` as allowed). One stale positive case (`INSERT INTO t SELECT * FROM s`) in the `test_allows` parametrize list swapped for `INSERT INTO t DEFAULT VALUES`.
- `CHANGELOG.md`: new file at repo root, Keep-a-Changelog format, four sections (Unreleased empty; 2.0.0 unreleased with all merged-to-main PRs; 2.0.0rc2; 2.0.0rc1; 1.0.2).

### Intentionally left allowed

`CREATE TABLE ... AS SELECT` and `SELECT ... INTO` are unbounded row copies in the same family as `INSERT ... SELECT`, but the team chose to leave them allowed — they're the common way to materialize a snapshot from a query and blocking them broke a valid workflow. Regression tests (`test_create_table_as_select_allowed`, `test_select_into_allowed`, `test_create_unlogged_table_as_select_allowed`) pin this choice.

## Automated tests

- `uv run pytest tests/test_guardrails.py` — 147 passed
- `uv run pytest tests/` (full suite, unit + integration against real YB) — 317 passed

## Manual test plan

Run the whole batch through the real stdio server with `YB_MCP_MAX_INSERT_ROWS=2` so both the new INSERT-SELECT block and the pre-existing VALUES-count cap are testable side-by-side.

**Setup**

```
cd /path/to/yugabytedb-mcp-server
```

```
psql "host=127.0.0.1 port=5433 user=yugabyte dbname=yugabyte" -c "DROP TABLE IF EXISTS t22131, t22131_plain, snap22131, snap22131b CASCADE; DROP FUNCTION IF EXISTS f22131(), f22131b(); DROP PROCEDURE IF EXISTS p22131(); CREATE TABLE t22131 (id int);"
```

Save the following 14 tool calls to `/tmp/db22131_manual.jsonl` (one line each, exact contents in [`tests/test_guardrails.py`](tests/test_guardrails.py) also):

```
{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"manual","version":"1"}}}
{"jsonrpc":"2.0","method":"notifications/initialized"}
{"jsonrpc":"2.0","id":100,"method":"tools/call","params":{"name":"run_write_query","arguments":{"query":"INSERT INTO t22131 SELECT generate_series(1, 50)"}}}
{"jsonrpc":"2.0","id":101,"method":"tools/call","params":{"name":"run_write_query","arguments":{"query":"WITH src AS (SELECT id FROM t22131) INSERT INTO t22131 SELECT * FROM src"}}}
{"jsonrpc":"2.0","id":102,"method":"tools/call","params":{"name":"run_write_query","arguments":{"query":"CREATE FUNCTION f22131() RETURNS int LANGUAGE SQL AS $q$ SELECT 1 $q$"}}}
{"jsonrpc":"2.0","id":103,"method":"tools/call","params":{"name":"run_write_query","arguments":{"query":"CREATE FUNCTION f22131b() RETURNS int SECURITY DEFINER LANGUAGE SQL AS $q$ SELECT 1 $q$"}}}
{"jsonrpc":"2.0","id":104,"method":"tools/call","params":{"name":"run_write_query","arguments":{"query":"CREATE PROCEDURE p22131() LANGUAGE plpgsql AS $q$ BEGIN END $q$"}}}
{"jsonrpc":"2.0","id":105,"method":"tools/call","params":{"name":"run_write_query","arguments":{"query":"ALTER FUNCTION does_not_exist() SECURITY DEFINER"}}}
{"jsonrpc":"2.0","id":106,"method":"tools/call","params":{"name":"run_write_query","arguments":{"query":"ALTER PROCEDURE does_not_exist() SECURITY DEFINER"}}}
{"jsonrpc":"2.0","id":200,"method":"tools/call","params":{"name":"run_write_query","arguments":{"query":"CREATE TABLE snap22131 AS SELECT 1 AS x"}}}
{"jsonrpc":"2.0","id":201,"method":"tools/call","params":{"name":"run_write_query","arguments":{"query":"SELECT 1 AS x INTO snap22131b"}}}
{"jsonrpc":"2.0","id":202,"method":"tools/call","params":{"name":"run_write_query","arguments":{"query":"INSERT INTO t22131 (id) VALUES (1)"}}}
{"jsonrpc":"2.0","id":203,"method":"tools/call","params":{"name":"run_write_query","arguments":{"query":"INSERT INTO t22131 (id) VALUES (1), (2)"}}}
{"jsonrpc":"2.0","id":204,"method":"tools/call","params":{"name":"run_write_query","arguments":{"query":"INSERT INTO t22131 (id) VALUES (1), (2), (3)"}}}
{"jsonrpc":"2.0","id":205,"method":"tools/call","params":{"name":"run_write_query","arguments":{"query":"INSERT INTO t22131 DEFAULT VALUES"}}}
{"jsonrpc":"2.0","id":206,"method":"tools/call","params":{"name":"run_write_query","arguments":{"query":"CREATE TABLE t22131_plain (id int)"}}}
```

**Run**

```
YUGABYTEDB_URL="host=127.0.0.1 port=5433 user=yugabyte dbname=yugabyte" YB_MCP_ENABLE_WRITE_QUERY=true YB_MCP_MAX_INSERT_ROWS=2 bash -c '{ cat /tmp/db22131_manual.jsonl; sleep 8; } | uv run yugabytedb-mcp --transport stdio 2>/dev/null | jq -c "select(.id>=100) | {id, r: (.result.content[0].text | fromjson)}"' | sort -t: -k2n
```

**Verify each row**

Blocked (8):

- [x] `id 100` — `INSERT INTO t22131 SELECT generate_series(1, 50)` → `error: INSERT … SELECT is not allowed on the write tool …`, `blocked_by_guardrail: true`
- [x] `id 101` — `WITH src AS (SELECT id FROM t22131) INSERT INTO t22131 SELECT * FROM src` → same error (nested SELECT via CTE still caught)
- [x] `id 102` — `CREATE FUNCTION f22131() …` → `error: CREATE FUNCTION is not allowed`, `blocked_by_guardrail: true`
- [x] `id 103` — `CREATE FUNCTION f22131b() … SECURITY DEFINER …` → same error (SECURITY DEFINER variant)
- [x] `id 104` — `CREATE PROCEDURE p22131() …` → `error: CREATE PROCEDURE is not allowed`, `blocked_by_guardrail: true`
- [x] `id 105` — `ALTER FUNCTION does_not_exist() SECURITY DEFINER` → `error: ALTER FUNCTION is not allowed`, `blocked_by_guardrail: true`
- [x] `id 106` — `ALTER PROCEDURE does_not_exist() SECURITY DEFINER` → `error: ALTER PROCEDURE is not allowed`, `blocked_by_guardrail: true`
- [x] `id 204` — `INSERT INTO t22131 (id) VALUES (1), (2), (3)` → `error: INSERT contains 3 rows, which exceeds the maximum of 2 rows …`, `blocked_by_guardrail: true` (confirms the pre-existing `YB_MCP_MAX_INSERT_ROWS` cap still fires)

Allowed (6):

- [x] `id 200` — `CREATE TABLE snap22131 AS SELECT 1 AS x` → `{"rows_affected": 1}`
- [x] `id 201` — `SELECT 1 AS x INTO snap22131b` → `{"rows_affected": 1}`
- [x] `id 202` — `INSERT INTO t22131 (id) VALUES (1)` → `{"rows_affected": 1}`
- [x] `id 203` — `INSERT INTO t22131 (id) VALUES (1), (2)` → `{"rows_affected": 2}` (exactly at cap, allowed)
- [x] `id 205` — `INSERT INTO t22131 DEFAULT VALUES` → `{"rows_affected": 1}` (bounded single-row insert stays allowed)
- [x] `id 206` — `CREATE TABLE t22131_plain (id int)` → `{"rows_affected": -1}` (plain DDL, no rows copied)

**Cleanup**

```
psql "host=127.0.0.1 port=5433 user=yugabyte dbname=yugabyte" -c "DROP TABLE IF EXISTS t22131, t22131_plain, snap22131, snap22131b CASCADE; DROP FUNCTION IF EXISTS f22131(), f22131b(); DROP PROCEDURE IF EXISTS p22131();"
```