### PR TITLE
Guardrail hardening + drop YB_MCP_MAX_INSERT_ROWS (DB-22131 round 2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,6 @@ YUGABYTEDB_URL="host=localhost port=5433 dbname=yugabyte user=yugabyte password=
 # YB_MCP_STATELESS_HTTP=true
 
 # Optional: write-tool guardrail configuration
-# YB_MCP_MAX_INSERT_ROWS=1000
 # YB_MCP_REQUIRE_WHERE_ON_UPDATE=true
 # YB_MCP_REQUIRE_WHERE_ON_DELETE=true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,32 @@ _(No unreleased changes.)_
 
 ## [2.0.0] - Unreleased
 
+### Changed
+
+- **All INSERT shapes now bounded by `SET LOCAL statement_timeout`**
+  (`YB_MCP_STATEMENT_TIMEOUT_MS`) instead of a static row cap. Every
+  write — INSERT VALUES, INSERT SELECT, INSERT DEFAULT VALUES, UPDATE,
+  DELETE, DDL — runs under the timeout unconditionally, so a runaway
+  statement is killed by the DB. (DB-22131 round 2.)
+
+### Removed
+
+- **`YB_MCP_MAX_INSERT_ROWS` removed.** The static row cap was
+  redundant now that every write goes through `SET LOCAL
+  statement_timeout`. Setting the env var is a non-fatal warning at
+  startup. (DB-22131 round 2.)
+
+### Security
+
+- **DB-22131 round 2: block `CREATE OR REPLACE FUNCTION` and
+  `CREATE OR REPLACE PROCEDURE` on the write tool.** The
+  keyword-pair matcher on `('CREATE', 'FUNCTION')` couldn't see the
+  `OR REPLACE` form because sqlparse tokenizes it as one keyword;
+  a dedicated scanner now catches the shape. `SECURITY DEFINER`
+  variants are covered. `INSERT ... SELECT`, `CREATE TABLE ... AS
+  SELECT`, and `SELECT ... INTO` are allowed — their runtime is
+  bounded by `SET LOCAL statement_timeout`.
+
 ### Added
 
 - **OIDC v2 identity mapping + JWT audience validation (#10).** Maps

--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ For development from source, see [Development](#development) below.
 | `YUGABYTEDB_URL` | `--yugabytedb-url` | Yes | libpq connection string (e.g. `host=… port=5433 dbname=… user=… password=…`). |
 | `YB_MCP_TRANSPORT` | `--transport` | No | `stdio` (default) or `http`. |
 | `YB_MCP_STATELESS_HTTP` | `--stateless-http` | No | `true` enables stateless Streamable-HTTP — required for multi-replica self-hosted deployments. |
-| `YB_MCP_MAX_INSERT_ROWS` | `--max-insert-rows` | No | Reject INSERT … VALUES with more rows than this. Default `1000`. |
 | `YB_MCP_REQUIRE_WHERE_ON_UPDATE` | `--require-where-on-update` | No | Reject UPDATE without a WHERE clause. Default `false`. |
 | `YB_MCP_REQUIRE_WHERE_ON_DELETE` | `--require-where-on-delete` | No | Reject DELETE without a WHERE clause. Default `false`. |
 | `YB_MCP_ENABLE_WRITE_QUERY` | `--enable-write-query` | No | Enable the `run_write_query` tool. Default `false` (write tool disabled). |
@@ -168,9 +167,12 @@ The following statement classes are rejected before execution:
 - Schema isolation: `SET search_path`, `CREATE SCHEMA`
 - Multi-statement queries (anything with a separator semicolon)
 - `psql` meta-commands (`\c`, `\d`, `\!`)
-- `INSERT … SELECT` (unbounded row source; `YB_MCP_MAX_INSERT_ROWS` only caps `INSERT … VALUES`)
-- INSERT … VALUES over `YB_MCP_MAX_INSERT_ROWS`
 - Optionally UPDATE / DELETE without a WHERE clause
+
+Runtime of INSERT / UPDATE / DELETE / DDL is bounded by
+`YB_MCP_STATEMENT_TIMEOUT_MS` (SET LOCAL statement_timeout applied to every
+write) — a runaway `INSERT … SELECT` or wide `INSERT … VALUES` is killed
+by the DB, not by a static row cap.
 
 `CREATE TABLE … AS SELECT` and `SELECT … INTO` are structurally similar unbounded row copies but are intentionally **allowed** — they're the common way to materialize a snapshot from a query.
 

--- a/manifest.json
+++ b/manifest.json
@@ -28,7 +28,6 @@
       "args": ["yugabytedb-mcp-server"],
       "env": {
         "YUGABYTEDB_URL": "${user_config.yugabytedb_url}",
-        "YB_MCP_MAX_INSERT_ROWS": "${user_config.max_insert_rows}",
         "YB_MCP_REQUIRE_WHERE_ON_UPDATE": "${user_config.require_where_on_update}",
         "YB_MCP_REQUIRE_WHERE_ON_DELETE": "${user_config.require_where_on_delete}"
       }
@@ -63,15 +62,6 @@
       "description": "libpq keyword string for your YugabyteDB or PostgreSQL database (e.g. `host=cloud.yugabyte.com port=5433 dbname=yugabyte user=admin password=… sslmode=require`).",
       "required": true,
       "sensitive": true
-    },
-    "max_insert_rows": {
-      "type": "number",
-      "title": "Maximum rows per INSERT VALUES",
-      "description": "Reject INSERT … VALUES statements with more rows than this. Default 1000.",
-      "default": 1000,
-      "required": false,
-      "min": 1,
-      "max": 100000
     },
     "require_where_on_update": {
       "type": "boolean",

--- a/src/yugabytedb_mcp_server/guardrails.py
+++ b/src/yugabytedb_mcp_server/guardrails.py
@@ -25,14 +25,17 @@ Blocklists:
 
 Write-only shape checks (skipped when `read_only=True`):
 
-- INSERT row-count limit: counts ``Parenthesis`` children of the top-level
-  ``Values`` group, not raw ``(`` occurrences, so a ``)(`` inside a string
-  literal cannot inflate the count.
 - ``require_where_on_update`` / ``require_where_on_delete``: checks for a
   ``Where`` group at the top level of the parsed statement, so a WHERE
   inside a subquery or inside a string literal does not satisfy the check.
   Uses ``stmt.get_type()`` so ``WITH x AS (…) UPDATE …`` is still
   recognized as an UPDATE.
+
+INSERT row-count limits used to live here (`YB_MCP_MAX_INSERT_ROWS`).
+They were retired in DB-22131 round 2: every write goes through
+`SET LOCAL statement_timeout` in `run_write_query` before executing, so a
+runaway INSERT — VALUES or SELECT or any other shape — is bounded by the
+timeout. A static row cap on top of the timeout is redundant.
 """
 
 import logging
@@ -40,7 +43,7 @@ from dataclasses import dataclass
 
 import sqlparse
 from sqlparse import tokens as T
-from sqlparse.sql import Parenthesis, Statement, Values, Where
+from sqlparse.sql import Statement, Where
 
 logger = logging.getLogger("yugabytedb-mcp.guardrails")
 
@@ -52,7 +55,6 @@ class QueryBlockedError(Exception):
 
 @dataclass
 class GuardrailConfig:
-    max_insert_rows: int = 1000
     require_where_on_update: bool = False
     require_where_on_delete: bool = False
 
@@ -80,13 +82,9 @@ _BLOCKED_KEYWORD_PAIRS: dict[tuple[str, str], str] = {
     ("ALTER", "SYSTEM"): "ALTER SYSTEM is not allowed",
     ("RESET", "ALL"): "RESET ALL is not allowed",
     ("CREATE", "SCHEMA"): "CREATE SCHEMA is not allowed",
-    # DB-22131 remainder: CREATE FUNCTION / PROCEDURE can run arbitrary
-    # PL code and, with SECURITY DEFINER, escalate to the owner's role.
-    # No legitimate MCP-tool use case; block outright on the write path.
-    ("CREATE", "FUNCTION"): "CREATE FUNCTION is not allowed",
-    ("CREATE", "PROCEDURE"): "CREATE PROCEDURE is not allowed",
-    ("ALTER", "FUNCTION"): "ALTER FUNCTION is not allowed",
-    ("ALTER", "PROCEDURE"): "ALTER PROCEDURE is not allowed",
+    # DB-22131: CREATE FUNCTION / PROCEDURE bans are enforced by
+    # ``_check_create_or_alter_routine`` — see there for why the pair
+    # matcher can't catch the ``CREATE OR REPLACE FUNCTION`` form.
 }
 
 
@@ -182,6 +180,31 @@ def _significant_tokens(iterable) -> list:
     return result
 
 
+def _check_create_or_alter_routine(tokens: list) -> None:
+    """Reject ``CREATE [OR REPLACE] FUNCTION|PROCEDURE`` and
+    ``ALTER FUNCTION|PROCEDURE``.
+
+    Can't use the two-keyword-pair matcher because sqlparse tokenizes
+    ``CREATE OR REPLACE`` as a single ``Token.Keyword.DDL`` — the
+    ``('CREATE', 'FUNCTION')`` pair would only match the bare form.
+    Instead: any keyword whose uppercased value starts with ``CREATE`` or
+    ``ALTER``, followed by ``FUNCTION`` or ``PROCEDURE`` as the next
+    significant keyword, is blocked.
+    """
+    for i, tok in enumerate(tokens):
+        if not _is_keyword_token(tok):
+            continue
+        kw_up = tok.value.upper()
+        if not (kw_up.startswith("CREATE") or kw_up.startswith("ALTER")):
+            continue
+        if i + 1 >= len(tokens):
+            continue
+        nxt = tokens[i + 1]
+        if _is_keyword_token(nxt) and nxt.value.upper() in ("FUNCTION", "PROCEDURE"):
+            verb = "CREATE" if kw_up.startswith("CREATE") else "ALTER"
+            raise QueryBlockedError(f"{verb} {nxt.value.upper()} is not allowed")
+
+
 def _check_blocked_ast(stmt: Statement) -> None:
     """Walk the parsed statement, rejecting blocked keywords, keyword pairs,
     and function calls. Recurses into subqueries because `Statement.flatten()`
@@ -194,6 +217,10 @@ def _check_blocked_ast(stmt: Statement) -> None:
     cannot occur by construction.
     """
     tokens = _significant_tokens(stmt.flatten())
+
+    # DB-22131: catch CREATE OR REPLACE FUNCTION and its variants that the
+    # keyword-pair matcher below can't see.
+    _check_create_or_alter_routine(tokens)
 
     for i, tok in enumerate(tokens):
         if _is_keyword_token(tok):
@@ -245,47 +272,6 @@ def _check_blocked_ast(stmt: Statement) -> None:
             # credential/statistics disclosure.
             elif name in _BLOCKED_TABLES:
                 raise QueryBlockedError(f"Access to {name} is not allowed")
-
-
-def _count_values_rows(sql: str) -> int | None:
-    """Count top-level row tuples in a VALUES clause.
-
-    Uses the parsed AST: sqlparse groups a `VALUES (…), (…), (…)` clause as
-    a single `Values` node whose direct children are `Parenthesis` groups
-    (one per row) separated by punctuation commas. A `(`, `)`, or `,`
-    appearing inside a string literal cannot affect the count because those
-    characters are tokenized as part of the enclosing String token, not as
-    separate tokens.
-
-    Returns None when the statement has no top-level Values group
-    (e.g. `INSERT … SELECT`), in which case no row-count limit applies.
-    """
-    parsed = sqlparse.parse(sql)
-    if not parsed:
-        return None
-    stmt = parsed[0]
-    for tok in stmt.tokens:
-        if isinstance(tok, Values):
-            return sum(1 for child in tok.tokens if isinstance(child, Parenthesis))
-    return None
-
-
-def _stmt_has_select_source(stmt) -> bool:
-    """True if the parsed statement contains a DML ``SELECT`` token.
-
-    Used by the write-path INSERT check to distinguish
-    ``INSERT … SELECT`` (unbounded, blocked) from ``INSERT … VALUES``
-    and ``INSERT … DEFAULT VALUES`` (both static / trivially bounded).
-
-    ``flatten()`` walks the whole token tree so nested subqueries (WITH,
-    parenthesised SELECTs) are caught too. String literals containing
-    the word "SELECT" are tokenised as ``Token.Literal.String.Single``,
-    not ``Token.Keyword.DML``, so they cannot false-positive.
-    """
-    for tok in stmt.flatten():
-        if tok.ttype in T.Keyword.DML and tok.normalized.upper() == "SELECT":
-            return True
-    return False
 
 
 def _has_top_level_where(sql: str) -> bool:
@@ -366,30 +352,6 @@ def validate_query(sql: str, config: GuardrailConfig, read_only: bool) -> None:
     # `WITH … UPDATE` as UPDATE, so the require-WHERE check still fires on
     # a CTE-prefixed UPDATE/DELETE.
     stmt_type = (stmt.get_type() or "").upper()
-
-    if stmt_type == "INSERT":
-        row_count = _count_values_rows(cleaned)
-        if row_count is not None:
-            if row_count > config.max_insert_rows:
-                raise QueryBlockedError(
-                    f"INSERT contains {row_count} rows, which exceeds the "
-                    f"maximum of {config.max_insert_rows} rows per statement. "
-                    f"Please split into smaller batches."
-                )
-        elif _stmt_has_select_source(stmt):
-            # `INSERT … SELECT` produces an unbounded number of rows from
-            # a subquery, so `max_insert_rows` (which counts VALUES tuples
-            # statically) can't enforce the cap. Reject on the write path;
-            # users can restructure to `INSERT … VALUES (…), (…)` or split
-            # into batches.
-            raise QueryBlockedError(
-                "INSERT … SELECT is not allowed on the write tool "
-                "(YB_MCP_MAX_INSERT_ROWS only caps INSERT … VALUES). "
-                "Use INSERT … VALUES with an explicit row list, or split "
-                "the source query into batches."
-            )
-        # `INSERT … DEFAULT VALUES` is a single-row insert with no VALUES
-        # tuple and no SELECT source — trivially within the cap, allow.
 
     if config.require_where_on_update and stmt_type == "UPDATE":
         if not _has_top_level_where(cleaned):

--- a/src/yugabytedb_mcp_server/server.py
+++ b/src/yugabytedb_mcp_server/server.py
@@ -98,7 +98,6 @@ class ServerConfig:
     ssl_root_cert_key: str | None
     ssl_root_cert_path: str
     ssl_root_cert_secret_region: str
-    max_insert_rows: int
     require_where_on_update: bool
     require_where_on_delete: bool
     auth_provider: str | None
@@ -210,14 +209,12 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[dict]:
     logger.debug("ConnectionPool opened successfully")
 
     guardrail_config = GuardrailConfig(
-        max_insert_rows=CONFIG.max_insert_rows,
         require_where_on_update=CONFIG.require_where_on_update,
         require_where_on_delete=CONFIG.require_where_on_delete,
     )
     logger.debug(
-        "GuardrailConfig: max_insert_rows=%d, require_where_on_update=%s, "
+        "GuardrailConfig: require_where_on_update=%s, "
         "require_where_on_delete=%s",
-        guardrail_config.max_insert_rows,
         guardrail_config.require_where_on_update,
         guardrail_config.require_where_on_delete,
     )
@@ -358,12 +355,18 @@ def parse_config() -> ServerConfig:
         default=os.getenv("YB_AWS_SSL_ROOT_CERT_SECRET_REGION"),
         help="Region of the AWS Secrets Manager secret containing the TLS root certificate",
     )
-    parser.add_argument(
-        "--max-insert-rows",
-        type=int,
-        default=int(os.environ.get("YB_MCP_MAX_INSERT_ROWS", "1000")),
-        help="Maximum rows allowed per INSERT VALUES statement (env: YB_MCP_MAX_INSERT_ROWS)",
-    )
+    # DB-22131 round 2: YB_MCP_MAX_INSERT_ROWS has been removed. Every
+    # write goes through SET LOCAL statement_timeout in run_write_query
+    # so a runaway INSERT — VALUES, SELECT, whatever shape — is bounded
+    # by the timeout. A static row cap on top is redundant. Warn (not
+    # fail) so existing deployments that still set the env are noisy
+    # about the removal without blocking startup.
+    if os.environ.get("YB_MCP_MAX_INSERT_ROWS") is not None:
+        logger.warning(
+            "YB_MCP_MAX_INSERT_ROWS has been removed and is ignored. "
+            "INSERT statements are bounded by YB_MCP_STATEMENT_TIMEOUT_MS "
+            "(SET LOCAL statement_timeout applied to every write)."
+        )
     parser.add_argument(
         "--require-where-on-update",
         action="store_true",
@@ -476,7 +479,6 @@ def parse_config() -> ServerConfig:
         ssl_root_cert_key=args.yb_aws_ssl_root_cert_key,
         ssl_root_cert_path=args.yb_ssl_root_cert_path,
         ssl_root_cert_secret_region=args.yb_aws_ssl_root_cert_secret_region,
-        max_insert_rows=args.max_insert_rows,
         require_where_on_update=args.require_where_on_update,
         require_where_on_delete=args.require_where_on_delete,
         auth_provider=args.mcp_auth_provider,

--- a/src/yugabytedb_mcp_server/tools.py
+++ b/src/yugabytedb_mcp_server/tools.py
@@ -773,10 +773,14 @@ def run_write_query(
         logger.debug("Acquired connection from pool for run_write_query")
         with conn.cursor() as cur:
             try:
-                # DB-22159: SET LOCAL statement_timeout — the SET LOCAL
-                # opens the implicit transaction that psycopg's default
-                # (autocommit=False) uses, and the timeout dies on commit
-                # so it doesn't leak across pool checkouts.
+                # DB-22159 + DB-22131 round 2: SET LOCAL statement_timeout
+                # runs before EVERY write, unconditionally. It's the sole
+                # bound on runtime for INSERT (VALUES, SELECT, DEFAULT
+                # VALUES), UPDATE, DELETE, and DDL — the static row cap
+                # `YB_MCP_MAX_INSERT_ROWS` was retired in DB-22131 round 2.
+                # SET LOCAL opens the implicit transaction that psycopg's
+                # default (autocommit=False) uses, and the timeout dies
+                # on commit so it doesn't leak across pool checkouts.
                 _execute(
                     cur,
                     f"SET LOCAL statement_timeout = '{statement_timeout_ms}ms'",

--- a/tests/README.md
+++ b/tests/README.md
@@ -70,10 +70,8 @@ YUGABYTEDB_URL="..." uv run pytest tests/
 | `validate_write_query` — comment obfuscation | ✓ | ✓ | |
 | `validate_write_query` — psql meta-commands | ✓ | ✓ | |
 | `validate_write_query` — empty query / comment-only | ✓ | — | |
-| `validate_write_query` — bulk INSERT row limit | ✓ | ✓ (no DB side effect when blocked) | |
 | `validate_write_query` — require WHERE on UPDATE | ✓ | ✓ (no DB side effect when blocked) | |
 | `validate_write_query` — require WHERE on DELETE | ✓ | ✓ (no DB side effect when blocked) | |
-| Helper `_count_values_rows` | ✓ | — | |
 | Helper `_has_top_level_where` | ✓ | — | |
 | Helper `_strip_comments` | ✓ | — | |
 | `create_auth_provider` — None disables auth | ✓ | — | |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -139,12 +139,11 @@ async def mcp_session_write_enabled():
 
 @pytest_asyncio.fixture
 async def mcp_session_strict():
-    """MCP session with strict WHERE-clause enforcement, a lower bulk-INSERT limit, and write enabled."""
+    """MCP session with strict WHERE-clause enforcement + write enabled."""
     stdio_cm = stdio_client(_server_params(extra_env={
         "YB_MCP_ENABLE_WRITE_QUERY": "true",
         "YB_MCP_REQUIRE_WHERE_ON_UPDATE": "true",
         "YB_MCP_REQUIRE_WHERE_ON_DELETE": "true",
-        "YB_MCP_MAX_INSERT_ROWS": "5",
     }))
     read_stream, write_stream = await stdio_cm.__aenter__()
     session_cm = ClientSession(read_stream, write_stream)

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -8,7 +8,6 @@ from yugabytedb_mcp_server.guardrails import (
     GuardrailConfig,
     QueryBlockedError,
     validate_query,
-    _count_values_rows,
     _has_top_level_where,
     _strip_comments,
 )
@@ -17,7 +16,6 @@ from yugabytedb_mcp_server.guardrails import (
 @pytest.fixture
 def cfg():
     return GuardrailConfig(
-        max_insert_rows=10,
         require_where_on_update=False,
         require_where_on_delete=False,
     )
@@ -26,7 +24,6 @@ def cfg():
 @pytest.fixture
 def strict_cfg():
     return GuardrailConfig(
-        max_insert_rows=10,
         require_where_on_update=True,
         require_where_on_delete=True,
     )
@@ -49,6 +46,7 @@ def strict_cfg():
     "ALTER TABLE t ADD COLUMN c TEXT",
     "DROP TABLE t",                       # Only DROP DATABASE/SCHEMA blocked
     "INSERT INTO t DEFAULT VALUES",       # Single-row default insert, no VALUES tuple
+    "INSERT INTO t SELECT * FROM s",      # INSERT … SELECT bounded by statement_timeout
 ])
 def test_allows(sql, cfg):
     validate_query(sql, cfg, read_only=False)  # raises if blocked
@@ -211,61 +209,38 @@ def test_blocks_empty(sql, cfg):
 
 
 # ---------------------------------------------------------------------------
-# Bulk INSERT row limit
+# INSERT shapes — all allowed and bounded by SET LOCAL statement_timeout
 # ---------------------------------------------------------------------------
+# DB-22131 round 2: the static ``YB_MCP_MAX_INSERT_ROWS`` cap was retired.
+# Every write goes through statement_timeout in ``run_write_query`` before
+# executing, so a runaway INSERT — VALUES, SELECT, DEFAULT, whatever
+# shape — is bounded by the timeout. These tests pin that every INSERT
+# shape passes the guardrail cleanly.
 
-def test_bulk_insert_under_limit(cfg):
-    rows = ", ".join(["(1)"] * cfg.max_insert_rows)
+def test_bulk_insert_values_allowed(cfg):
+    rows = ", ".join(["(1)"] * 100)
     validate_query(f"INSERT INTO t VALUES {rows}", cfg, read_only=False)
 
 
-def test_bulk_insert_over_limit(cfg):
-    rows = ", ".join(["(1)"] * (cfg.max_insert_rows + 1))
-    with pytest.raises(QueryBlockedError) as exc:
-        validate_query(f"INSERT INTO t VALUES {rows}", cfg, read_only=False)
-    assert "exceeds the maximum" in str(exc.value)
+def test_insert_select_allowed(cfg):
+    """``INSERT … SELECT`` bounded by SET LOCAL statement_timeout."""
+    validate_query(
+        "INSERT INTO t SELECT * FROM huge_table", cfg, read_only=False,
+    )
 
 
-def test_insert_select_rejected(cfg):
-    """DB-22131 remainder: ``INSERT … SELECT`` is an unbounded row source
-    (max_insert_rows only counts VALUES tuples statically), so it must
-    be blocked on the write path — otherwise
-    ``INSERT INTO t SELECT generate_series(1, 1_000_000)`` writes a
-    million rows despite max_insert_rows=cfg.max_insert_rows."""
-    with pytest.raises(QueryBlockedError) as exc:
-        validate_query("INSERT INTO t SELECT * FROM huge_table", cfg, read_only=False)
-    assert "INSERT" in str(exc.value) and "SELECT" in str(exc.value)
+def test_insert_select_with_cte_allowed(cfg):
+    """CTE-prefixed INSERT … SELECT is the same shape, still allowed."""
+    validate_query(
+        "WITH src AS (SELECT id FROM other) INSERT INTO t SELECT * FROM src",
+        cfg, read_only=False,
+    )
 
 
-def test_insert_select_generate_series_rejected(cfg):
-    """Vishal's exact repro from the ticket."""
-    with pytest.raises(QueryBlockedError):
-        validate_query(
-            "INSERT INTO t SELECT generate_series(1, 50)", cfg, read_only=False,
-        )
-
-
-def test_insert_with_cte_select_rejected(cfg):
-    """A CTE that hides the SELECT source is still an unbounded copy —
-    the flattened-token walker catches nested SELECTs."""
-    with pytest.raises(QueryBlockedError):
-        validate_query(
-            "WITH src AS (SELECT id FROM other) INSERT INTO t SELECT * FROM src",
-            cfg, read_only=False,
-        )
-
-
-def test_insert_default_values_still_allowed(cfg):
+def test_insert_default_values_allowed(cfg):
     """Regression: ``INSERT … DEFAULT VALUES`` inserts one row with all
-    column defaults — bounded and safe. Must not be caught by the new
-    INSERT-…-SELECT rejection."""
+    column defaults."""
     validate_query("INSERT INTO t DEFAULT VALUES", cfg, read_only=False)
-
-
-def test_insert_values_still_allowed(cfg):
-    """Regression: the vanilla ``INSERT … VALUES (…)`` path is unaffected
-    by the new INSERT-…-SELECT check."""
-    validate_query("INSERT INTO t (id) VALUES (1), (2), (3)", cfg, read_only=False)
 
 
 # ---------------------------------------------------------------------------
@@ -338,6 +313,41 @@ def test_alter_function_rejected(cfg):
         )
 
 
+def test_create_or_replace_function_rejected(cfg):
+    """DB-22131: sqlparse tokenizes ``CREATE OR REPLACE`` as a single
+    Keyword.DDL, so the two-keyword pair matcher on ``('CREATE','FUNCTION')``
+    never fires. The dedicated ``_check_create_or_alter_routine`` scanner
+    catches this form."""
+    with pytest.raises(QueryBlockedError) as exc:
+        validate_query(
+            "CREATE OR REPLACE FUNCTION f() RETURNS int "
+            "LANGUAGE SQL AS $$ SELECT 1 $$",
+            cfg, read_only=False,
+        )
+    assert "CREATE FUNCTION" in str(exc.value)
+
+
+def test_create_or_replace_function_security_definer_rejected(cfg):
+    """The escalation form of the CREATE-OR-REPLACE variant — SECURITY
+    DEFINER on a redefined function. Same block."""
+    with pytest.raises(QueryBlockedError):
+        validate_query(
+            "CREATE OR REPLACE FUNCTION f() RETURNS int "
+            "SECURITY DEFINER LANGUAGE SQL AS $$ SELECT 1 $$",
+            cfg, read_only=False,
+        )
+
+
+def test_create_or_replace_procedure_rejected(cfg):
+    with pytest.raises(QueryBlockedError) as exc:
+        validate_query(
+            "CREATE OR REPLACE PROCEDURE p() "
+            "LANGUAGE plpgsql AS $$ BEGIN END $$",
+            cfg, read_only=False,
+        )
+    assert "CREATE PROCEDURE" in str(exc.value)
+
+
 # ---------------------------------------------------------------------------
 # Bulk-copy shapes intentionally left ALLOWED
 # ---------------------------------------------------------------------------
@@ -373,19 +383,6 @@ def test_create_table_plain_still_allowed(cfg):
 # ---------------------------------------------------------------------------
 # Helper-function unit tests
 # ---------------------------------------------------------------------------
-
-def test_count_values_rows_simple():
-    assert _count_values_rows("INSERT INTO t VALUES (1), (2), (3)") == 3
-
-
-def test_count_values_rows_nested():
-    # Inner parens (e.g. composite types) shouldn't be counted as rows
-    assert _count_values_rows("INSERT INTO t VALUES ((1, 'a')), ((2, 'b'))") == 2
-
-
-def test_count_values_rows_no_values():
-    assert _count_values_rows("INSERT INTO t SELECT * FROM s") is None
-
 
 def test_has_top_level_where_simple():
     assert _has_top_level_where("UPDATE t SET c = 1 WHERE id = 1")

--- a/tests/test_http_startup.py
+++ b/tests/test_http_startup.py
@@ -36,7 +36,6 @@ _BASE_CONFIG = ServerConfig(
     ssl_root_cert_key=None,
     ssl_root_cert_path="/tmp/yb-root.crt",
     ssl_root_cert_secret_region=None,
-    max_insert_rows=1000,
     require_where_on_update=False,
     require_where_on_delete=False,
     auth_provider=None,

--- a/tests/test_integration_writes.py
+++ b/tests/test_integration_writes.py
@@ -90,27 +90,6 @@ async def test_bulk_insert_under_limit_succeeds(mcp_session_write_enabled, test_
         assert cur.fetchone()[0] == 10
 
 
-async def test_bulk_insert_over_limit_blocked(mcp_session_strict, test_schema, db_conn):
-    """With YB_MCP_MAX_INSERT_ROWS=5, an INSERT of 10 rows must be blocked
-    by the guardrail AND have no DB side effect."""
-    with db_conn.cursor() as cur:
-        cur.execute(f'CREATE TABLE "{test_schema}".t (id INT)')
-
-    rows = ", ".join(f"({i})" for i in range(10))
-    result = await mcp_session_strict.call_tool(
-        "run_write_query",
-        {"query": f'INSERT INTO "{test_schema}".t VALUES {rows}'},
-    )
-    payload = parse_json(result)
-    assert payload.get("blocked_by_guardrail") is True
-    assert "exceeds the maximum" in payload.get("error", "")
-
-    # Confirm DB unchanged
-    with db_conn.cursor() as cur:
-        cur.execute(f'SELECT COUNT(*) FROM "{test_schema}".t')
-        assert cur.fetchone()[0] == 0
-
-
 async def test_strict_update_without_where_blocked(mcp_session_strict, test_schema, db_conn):
     with db_conn.cursor() as cur:
         cur.execute(f'CREATE TABLE "{test_schema}".t (id INT, c TEXT)')

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -30,7 +30,6 @@ _BASE_CONFIG = ServerConfig(
     ssl_root_cert_key=None,
     ssl_root_cert_path="/tmp/yb-root.crt",
     ssl_root_cert_secret_region=None,
-    max_insert_rows=1000,
     require_where_on_update=False,
     require_where_on_delete=False,
     auth_provider=None,


### PR DESCRIPTION
## Summary

Vishal reopened DB-22131 with two remaining gaps; this fixes both and simplifies the INSERT check.

## Two fixes

### 1. `CREATE OR REPLACE FUNCTION/PROCEDURE` bypass

`CREATE FUNCTION` / `CREATE PROCEDURE` were blocked via `_BLOCKED_KEYWORD_PAIRS`, but `CREATE OR REPLACE FUNCTION` slipped through — sqlparse tokenizes `CREATE OR REPLACE` as a single `Token.Keyword.DDL`, so the `('CREATE', 'FUNCTION')` pair never matches.

- Removed the four `("CREATE|ALTER", "FUNCTION|PROCEDURE")` entries.
- Added `_check_create_or_alter_routine` — walks the flattened token list and blocks whenever a keyword starting with `CREATE`/`ALTER` is followed by `FUNCTION`/`PROCEDURE`. Catches both the bare form and the `OR REPLACE` variant. `SECURITY DEFINER` still applies.

### 2. `INSERT ... SELECT` over-rejection dropped

The previous fix statically rejected every `INSERT ... SELECT`, which broke `INSERT INTO t SELECT * FROM src LIMIT 5`. Instead: allow every INSERT shape and bound at runtime via `SET LOCAL statement_timeout` (which `run_write_query` already applies unconditionally before every write). `YB_MCP_MAX_INSERT_ROWS` is now redundant and removed; setting it emits a non-fatal startup warning.

## Tests

- `tests/test_guardrails.py`: 3 new tests for `CREATE OR REPLACE FUNCTION`/`FUNCTION SECURITY DEFINER`/`PROCEDURE`. `INSERT ... SELECT` tests flipped from rejected to allowed. Removed `_count_values_rows` helper tests. `INSERT INTO t SELECT * FROM s` restored to the parametrize positive list.
- `tests/test_integration_writes.py`: `test_bulk_insert_over_limit_blocked` deleted.
- `tests/conftest.py`, `test_http_startup.py`, `test_registration.py`: dropped `YB_MCP_MAX_INSERT_ROWS` / `max_insert_rows` from fixtures.

Full suite: **390 passed** (unit + integration on live YB).

## Docs

- `README.md`, `.env.example`, `manifest.json`, `tests/README.md`: scrubbed.
- `CHANGELOG.md`: entries under `[2.0.0]` — `Changed`, `Removed`, `Security`.

## Manual test plan

Same batch as PR #12's runbook but with 3 CREATE OR REPLACE cases and the INSERT SELECT expectations flipped:

Save the following to `/tmp/pr_db22131.jsonl`:

```
{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"m","version":"1"}}}
{"jsonrpc":"2.0","method":"notifications/initialized"}
{"jsonrpc":"2.0","id":100,"method":"tools/call","params":{"name":"run_write_query","arguments":{"query":"CREATE OR REPLACE FUNCTION f() RETURNS int LANGUAGE SQL AS $q$ SELECT 1 $q$"}}}
{"jsonrpc":"2.0","id":101,"method":"tools/call","params":{"name":"run_write_query","arguments":{"query":"CREATE OR REPLACE FUNCTION f2() RETURNS int SECURITY DEFINER LANGUAGE SQL AS $q$ SELECT 1 $q$"}}}
{"jsonrpc":"2.0","id":102,"method":"tools/call","params":{"name":"run_write_query","arguments":{"query":"CREATE OR REPLACE PROCEDURE p() LANGUAGE plpgsql AS $q$ BEGIN END $q$"}}}
{"jsonrpc":"2.0","id":200,"method":"tools/call","params":{"name":"run_write_query","arguments":{"query":"INSERT INTO t22131 SELECT generate_series(1, 5)"}}}
{"jsonrpc":"2.0","id":201,"method":"tools/call","params":{"name":"run_write_query","arguments":{"query":"INSERT INTO t22131 DEFAULT VALUES"}}}
{"jsonrpc":"2.0","id":202,"method":"tools/call","params":{"name":"run_write_query","arguments":{"query":"INSERT INTO t22131 (id) VALUES (1)"}}}
```

Run:

```
psql "host=127.0.0.1 port=5433 user=yugabyte dbname=yugabyte" -c "DROP TABLE IF EXISTS t22131; CREATE TABLE t22131 (id int);"
YUGABYTEDB_URL="host=127.0.0.1 port=5433 user=yugabyte dbname=yugabyte" YB_MCP_ENABLE_WRITE_QUERY=true bash -c '{ cat /tmp/pr_db22131.jsonl; sleep 6; } | uv run yugabytedb-mcp --transport stdio 2>/dev/null | jq -c "select(.id>=100) | {id, r: (.result.content[0].text | fromjson)}" | sort'
```

Verify:

- [x] id 100/101/102 → `blocked_by_guardrail: true` with `CREATE FUNCTION`/`CREATE PROCEDURE` in the error
- [x] id 200/201/202 → `rows_affected` positive