### PR TITLE
Resource limits round 2 (DB-22159): byte cap, summarize timeout, pool validation, connect_timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ _(No unreleased changes.)_
 
 ## [2.0.0] - Unreleased
 
+### Added
+
+- **`YB_MCP_MAX_RESULT_BYTES` cap.** Cumulative byte budget applied
+  while streaming rows from `run_read_only_query`. A wide-row query
+  (e.g. `SELECT repeat('x', 1_000_000) FROM generate_series(1, 100)`)
+  now truncates on bytes rather than materializing ~100 MiB before
+  the row cap is checked. Default: 50 MiB. (DB-22159 round 2.)
+- **`connect_timeout` on the pool conninfo.** Defaults to `10` when
+  the operator's `YUGABYTEDB_URL` doesn't set one, so a network
+  partition to the DB doesn't hang startup or pool checkouts
+  indefinitely. (DB-22159 round 2.)
+
+### Changed
+
+- **Pool sizing is validated at startup** — `pool_min_size >
+  pool_max_size` raises a clean `ValueError` before `pool.open`.
+  (DB-22159 round 2.)
+- **`summarize_database` now runs under `SET LOCAL statement_timeout`**,
+  matching the read / write tools. A slow `COUNT(*)` no longer
+  holds a pool connection indefinitely. (DB-22159 round 2.)
+
 ### Changed
 
 - **All INSERT shapes now bounded by `SET LOCAL statement_timeout`**

--- a/src/yugabytedb_mcp_server/server.py
+++ b/src/yugabytedb_mcp_server/server.py
@@ -199,9 +199,17 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[dict]:
     # is unlimited; without a cap, a network partition to the DB during
     # pool warm-up hangs startup indefinitely (or the pool acquire path
     # blocks the tool call for hundreds of seconds). Only add when the
-    # operator hasn't set one explicitly.
-    if "connect_timeout" not in database_url:
-        database_url += " connect_timeout=10"
+    # operator hasn't set one explicitly. libpq accepts both keyword form
+    # (`host=… connect_timeout=10`) and URI form
+    # (`postgresql://…?connect_timeout=10`) — space-appending to a URI
+    # mangles it into `?sslmode=… connect_timeout=10` which psycopg
+    # rejects. Detect the form and use the right separator.
+    if "connect_timeout" not in database_url.lower():
+        if database_url.startswith(("postgres://", "postgresql://")):
+            sep = "&" if "?" in database_url else "?"
+            database_url = f"{database_url}{sep}connect_timeout=10"
+        else:
+            database_url = f"{database_url} connect_timeout=10"
 
     # Connection string can contain a password — log only structural info.
     logger.debug(

--- a/src/yugabytedb_mcp_server/server.py
+++ b/src/yugabytedb_mcp_server/server.py
@@ -113,6 +113,7 @@ class ServerConfig:
     pool_max_size: int
     statement_timeout_ms: int
     max_result_rows: int
+    max_result_bytes: int
     max_query_len: int
 
 
@@ -175,6 +176,16 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[dict]:
         logger.critical("YUGABYTEDB_URL is not set")
         sys.exit(1)
 
+    # DB-22159 round-2: validate pool sizing at startup so a misconfig
+    # (min > max) fails with a clean error instead of a raw psycopg
+    # traceback at pool.open time.
+    if CONFIG.pool_min_size > CONFIG.pool_max_size:
+        raise ValueError(
+            f"YB_MCP_POOL_MIN_SIZE ({CONFIG.pool_min_size}) exceeds "
+            f"YB_MCP_POOL_MAX_SIZE ({CONFIG.pool_max_size}). Lower the "
+            f"minimum or raise the maximum."
+        )
+
     logger.info("Connecting to database...")
     database_url = CONFIG.yugabytedb_url
     cert_path = write_root_cert()
@@ -183,6 +194,14 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[dict]:
         if "sslrootcert" not in database_url:
             database_url += f" sslrootcert={cert_path}"
             logger.debug("Appended sslrootcert to connection string")
+
+    # DB-22159 round-2: bound the TCP connect attempt too. libpq's default
+    # is unlimited; without a cap, a network partition to the DB during
+    # pool warm-up hangs startup indefinitely (or the pool acquire path
+    # blocks the tool call for hundreds of seconds). Only add when the
+    # operator hasn't set one explicitly.
+    if "connect_timeout" not in database_url:
+        database_url += " connect_timeout=10"
 
     # Connection string can contain a password — log only structural info.
     logger.debug(
@@ -301,6 +320,7 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[dict]:
             # DB-22159 resource limits — read by tools.py at each call.
             "statement_timeout_ms": CONFIG.statement_timeout_ms,
             "max_result_rows": CONFIG.max_result_rows,
+            "max_result_bytes": CONFIG.max_result_bytes,
             "max_query_len": CONFIG.max_query_len,
         }
     finally:
@@ -459,6 +479,17 @@ def parse_config() -> ServerConfig:
              "(env: YB_MCP_MAX_RESULT_ROWS, default: 10000).",
     )
     parser.add_argument(
+        "--max-result-bytes",
+        type=_positive_int,
+        default=os.environ.get("YB_MCP_MAX_RESULT_BYTES", str(50 * 1024 * 1024)),
+        help="Cap the total byte size of a result set. Enforced while "
+             "streaming rows so a query like `SELECT repeat('x', 1_000_000) "
+             "FROM generate_series(1, 100)` can't OOM the process even with "
+             "max_result_rows large. Truncated responses carry a "
+             "`truncated: true` marker "
+             "(env: YB_MCP_MAX_RESULT_BYTES, default: 50 MiB).",
+    )
+    parser.add_argument(
         "--max-query-len",
         type=_positive_int,
         default=os.environ.get("YB_MCP_MAX_QUERY_LEN", "100000"),
@@ -491,6 +522,7 @@ def parse_config() -> ServerConfig:
         pool_max_size=args.pool_max_size,
         statement_timeout_ms=args.statement_timeout_ms,
         max_result_rows=args.max_result_rows,
+        max_result_bytes=args.max_result_bytes,
         max_query_len=args.max_query_len,
     )
 

--- a/src/yugabytedb_mcp_server/tools.py
+++ b/src/yugabytedb_mcp_server/tools.py
@@ -663,46 +663,58 @@ def run_read_only_query(
 
     with _conn_as_role(pool, role) as conn:
         logger.debug("Acquired connection from pool for run_read_only_query")
-        with conn.cursor() as cur:
+        # Control cursor drives BEGIN / SET LOCAL / ROLLBACK. The named
+        # cursor below runs the user's SELECT as a server-side cursor
+        # (`DECLARE … CURSOR FOR SELECT`) so rows are fetched on demand
+        # via `FETCH FORWARD N` instead of being materialized in a
+        # client-side buffer at execute() time. This is what actually
+        # makes the byte cap enforceable — a wide-row query no longer
+        # gets buffered wholesale before we count bytes.
+        with conn.cursor() as ctrl_cur:
             try:
-                _execute(cur, "BEGIN READ ONLY")
+                _execute(ctrl_cur, "BEGIN READ ONLY")
                 # DB-22159: SET LOCAL statement_timeout scopes the cap to
                 # this transaction only — the timeout dies with the ROLLBACK
                 # below, so it doesn't leak across pool checkouts.
                 _execute(
-                    cur,
+                    ctrl_cur,
                     f"SET LOCAL statement_timeout = '{statement_timeout_ms}ms'",
                 )
-                _execute(cur, query)
-                # DB-22159 round-2: stream rows one at a time and apply
-                # BOTH the row cap AND a cumulative byte budget. The old
-                # ``fetchmany(max+1)`` bounded row count only — a wide-row
-                # query (`SELECT repeat('x', 1_000_000) FROM
-                # generate_series(1, 100)`) still buffered ~100 MB before
-                # anyone counted rows. The byte cap trips as soon as the
-                # cumulative row size crosses ``max_result_bytes``.
-                rows = []
-                approx_bytes = 0
-                truncated_by_rows = False
-                truncated_by_bytes = False
-                for row in cur:
-                    if len(rows) >= max_result_rows:
-                        truncated_by_rows = True
-                        break
-                    # Approximate serialized cost: string length of each
-                    # value plus a couple of bytes for JSON delimiters
-                    # (`, ` between values, `[]` for the row). Cheap and
-                    # bounded — psycopg has already materialized this row
-                    # in memory to hand it to us, so the string coercion
-                    # doesn't add asymptotic overhead.
-                    row_bytes = sum(len(str(v)) for v in row) + 2 * len(row)
-                    if approx_bytes + row_bytes > max_result_bytes:
-                        truncated_by_bytes = True
-                        break
-                    rows.append(row)
-                    approx_bytes += row_bytes
-                truncated = truncated_by_rows or truncated_by_bytes
-                column_names = [desc[0] for desc in cur.description]
+                # DB-22159 round-2: server-side cursor + small itersize.
+                # psycopg3's client-side cursor buffers ALL rows at
+                # ``execute()`` time, defeating any downstream byte cap;
+                # a named cursor issues DECLARE/FETCH so the DB streams
+                # to us. itersize=10 keeps per-FETCH memory bounded to
+                # ~10 rows at whatever their intrinsic width happens to
+                # be, so a `SELECT repeat('x', N) FROM …` pathological
+                # case still buffers at most 10*N bytes per round-trip
+                # instead of every row × N.
+                with conn.cursor(name="mcp_read_only") as cur:
+                    cur.itersize = 10
+                    _execute(cur, query)
+                    rows = []
+                    approx_bytes = 0
+                    truncated_by_rows = False
+                    truncated_by_bytes = False
+                    for row in cur:
+                        if len(rows) >= max_result_rows:
+                            truncated_by_rows = True
+                            break
+                        # Approximate serialized cost: string length of
+                        # each value plus a couple of bytes for JSON
+                        # delimiters (`, ` between values, `[]` for the
+                        # row). Cheap and bounded — psycopg has already
+                        # materialized this row in memory to hand it to
+                        # us, so the string coercion doesn't add
+                        # asymptotic overhead.
+                        row_bytes = sum(len(str(v)) for v in row) + 2 * len(row)
+                        if approx_bytes + row_bytes > max_result_bytes:
+                            truncated_by_bytes = True
+                            break
+                        rows.append(row)
+                        approx_bytes += row_bytes
+                    truncated = truncated_by_rows or truncated_by_bytes
+                    column_names = [desc[0] for desc in cur.description]
                 # Use the parallel-arrays shape (PR #9 / DB-22203) so
                 # duplicate column names don't collapse; still robust to a
                 # `SELECT a.id, b.id FROM ...` after a join.
@@ -735,7 +747,7 @@ def run_read_only_query(
                 return f"Error executing query: {e}"
             finally:
                 try:
-                    _execute(cur, "ROLLBACK")
+                    _execute(ctrl_cur, "ROLLBACK")
                 except Exception as e:
                     logger.error("Failed to ROLLBACK read-only transaction: %s", e)
 

--- a/src/yugabytedb_mcp_server/tools.py
+++ b/src/yugabytedb_mcp_server/tools.py
@@ -467,7 +467,13 @@ def summarize_database(
     """
     logger.info("summarize_database called (schema=%s)", schema)
     summary: List[Dict[str, Any]] = []
-    pool = ctx.request_context.lifespan_context["pool"]
+    lifespan = ctx.request_context.lifespan_context
+    pool = lifespan["pool"]
+    # DB-22159 round-2: previously only run_read_only_query /
+    # run_write_query enforced the statement_timeout; a `COUNT(*)` over a
+    # huge table via summarize_database could hold a pool connection
+    # indefinitely. Apply the same cap here.
+    statement_timeout_ms = lifespan["statement_timeout_ms"]
 
     try:
         role = _get_db_role(ctx, requested_role=requested_role)
@@ -480,6 +486,10 @@ def summarize_database(
         with conn.cursor() as cur:
             try:
                 _execute(cur, "BEGIN READ ONLY")
+                _execute(
+                    cur,
+                    f"SET LOCAL statement_timeout = '{statement_timeout_ms}ms'",
+                )
 
                 # Initial tables lookup — if this fails there's nothing to
                 # iterate; report the error and unwind.
@@ -615,6 +625,7 @@ def run_read_only_query(
     max_query_len = lifespan["max_query_len"]
     statement_timeout_ms = lifespan["statement_timeout_ms"]
     max_result_rows = lifespan["max_result_rows"]
+    max_result_bytes = lifespan["max_result_bytes"]
 
     # Reject oversized queries BEFORE parsing or opening a connection.
     # Vishal observed a ~1MB write query burning ~6s of CPU in the
@@ -663,13 +674,34 @@ def run_read_only_query(
                     f"SET LOCAL statement_timeout = '{statement_timeout_ms}ms'",
                 )
                 _execute(cur, query)
-                # fetchmany(max+1) lets us detect truncation without paging
-                # the whole result set into memory first. `SELECT repeat('x',
-                # 100000000)` no longer OOMs the process.
-                rows = cur.fetchmany(max_result_rows + 1)
-                truncated = len(rows) > max_result_rows
-                if truncated:
-                    rows = rows[:max_result_rows]
+                # DB-22159 round-2: stream rows one at a time and apply
+                # BOTH the row cap AND a cumulative byte budget. The old
+                # ``fetchmany(max+1)`` bounded row count only — a wide-row
+                # query (`SELECT repeat('x', 1_000_000) FROM
+                # generate_series(1, 100)`) still buffered ~100 MB before
+                # anyone counted rows. The byte cap trips as soon as the
+                # cumulative row size crosses ``max_result_bytes``.
+                rows = []
+                approx_bytes = 0
+                truncated_by_rows = False
+                truncated_by_bytes = False
+                for row in cur:
+                    if len(rows) >= max_result_rows:
+                        truncated_by_rows = True
+                        break
+                    # Approximate serialized cost: string length of each
+                    # value plus a couple of bytes for JSON delimiters
+                    # (`, ` between values, `[]` for the row). Cheap and
+                    # bounded — psycopg has already materialized this row
+                    # in memory to hand it to us, so the string coercion
+                    # doesn't add asymptotic overhead.
+                    row_bytes = sum(len(str(v)) for v in row) + 2 * len(row)
+                    if approx_bytes + row_bytes > max_result_bytes:
+                        truncated_by_bytes = True
+                        break
+                    rows.append(row)
+                    approx_bytes += row_bytes
+                truncated = truncated_by_rows or truncated_by_bytes
                 column_names = [desc[0] for desc in cur.description]
                 # Use the parallel-arrays shape (PR #9 / DB-22203) so
                 # duplicate column names don't collapse; still robust to a
@@ -680,11 +712,16 @@ def run_read_only_query(
                 }
                 if truncated:
                     result["truncated"] = True
-                    result["returned_rows"] = max_result_rows
+                    result["returned_rows"] = len(rows)
+                    reason = (
+                        "YB_MCP_MAX_RESULT_ROWS "
+                        f"({max_result_rows})"
+                        if truncated_by_rows
+                        else f"YB_MCP_MAX_RESULT_BYTES ({max_result_bytes} bytes)"
+                    )
                     result["note"] = (
-                        f"Result set exceeded YB_MCP_MAX_RESULT_ROWS "
-                        f"({max_result_rows}). Add a LIMIT clause or "
-                        f"narrow the query to see the full result."
+                        f"Result set exceeded {reason}. Add a LIMIT clause "
+                        f"or narrow the query to see the full result."
                     )
                 logger.info(
                     "run_read_only_query returned %d rows × %d columns "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -159,14 +159,18 @@ async def mcp_session_strict():
 @pytest_asyncio.fixture
 async def mcp_session_capped():
     """MCP session with small resource caps for DB-22159 testing:
-    - statement_timeout: 1s (fast enough to fail-fast on pg_sleep)
+    - statement_timeout: 1s (fast enough to fail-fast on pg_sleep / a
+      long summarize_database scan)
     - max_result_rows: 3 (so a 10-row query truncates)
+    - max_result_bytes: 512 (wide-row query truncates by bytes even if
+      well under the row cap — DB-22159 round-2)
     - max_query_len: 200 bytes (so a moderately long query is pre-rejected)
     Write tool enabled so both read + write paths can be exercised."""
     stdio_cm = stdio_client(_server_params(extra_env={
         "YB_MCP_ENABLE_WRITE_QUERY": "true",
         "YB_MCP_STATEMENT_TIMEOUT_MS": "1000",
         "YB_MCP_MAX_RESULT_ROWS": "3",
+        "YB_MCP_MAX_RESULT_BYTES": "512",
         "YB_MCP_MAX_QUERY_LEN": "200",
     }))
     read_stream, write_stream = await stdio_cm.__aenter__()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -163,6 +163,56 @@ class TestPoolSizingValidation:
                 server_module.CONFIG = original
 
 
+class TestConnectTimeoutAppend:
+    """DB-22159 round-2 (post-review): when ``YUGABYTEDB_URL`` doesn't
+    already carry a ``connect_timeout`` we append one. The append has to
+    respect the two conninfo formats libpq accepts — keyword form
+    (space-separated) and URI form (query-string). Space-appending to a
+    URI mangles it (`?sslmode=disable connect_timeout=10` — psycopg
+    rejects with "extra key/value separator")."""
+
+    def _append(self, url: str) -> str:
+        """Mirror the logic in ``app_lifespan``."""
+        if "connect_timeout" in url.lower():
+            return url
+        if url.startswith(("postgres://", "postgresql://")):
+            sep = "&" if "?" in url else "?"
+            return f"{url}{sep}connect_timeout=10"
+        return f"{url} connect_timeout=10"
+
+    def test_keyword_form_bare(self):
+        assert self._append("host=localhost port=5433 dbname=yb user=yb") == (
+            "host=localhost port=5433 dbname=yb user=yb connect_timeout=10"
+        )
+
+    def test_keyword_form_already_set(self):
+        u = "host=localhost connect_timeout=5"
+        assert self._append(u) == u
+
+    def test_keyword_form_case_insensitive_already_set(self):
+        u = "Connect_Timeout=5 host=localhost"
+        assert self._append(u) == u
+
+    def test_uri_form_no_query(self):
+        assert self._append("postgresql://yb@localhost:5433/db") == (
+            "postgresql://yb@localhost:5433/db?connect_timeout=10"
+        )
+
+    def test_uri_form_with_query(self):
+        assert self._append(
+            "postgresql://yb@localhost:5433/db?sslmode=require"
+        ) == "postgresql://yb@localhost:5433/db?sslmode=require&connect_timeout=10"
+
+    def test_uri_form_already_set(self):
+        u = "postgresql://yb@localhost:5433/db?connect_timeout=5"
+        assert self._append(u) == u
+
+    def test_uri_short_scheme(self):
+        assert self._append("postgres://yb@localhost/db") == (
+            "postgres://yb@localhost/db?connect_timeout=10"
+        )
+
+
 class TestResourceLimitEnvValidation:
     """Bad env values fail startup with a clean argparse error, not a
     traceback."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -94,6 +94,11 @@ class TestResourceLimitDefaults:
         cfg = _parse_with_env({})
         assert cfg.max_query_len == 100_000
 
+    def test_max_result_bytes_default(self):
+        """DB-22159 round-2: 50 MiB default byte cap."""
+        cfg = _parse_with_env({})
+        assert cfg.max_result_bytes == 50 * 1024 * 1024
+
 
 class TestResourceLimitEnvParsing:
     """Env-var overrides populate ServerConfig correctly."""
@@ -118,11 +123,49 @@ class TestResourceLimitEnvParsing:
         cfg = _parse_with_env({"YB_MCP_MAX_QUERY_LEN": "1000"})
         assert cfg.max_query_len == 1_000
 
+    def test_max_result_bytes_from_env(self):
+        cfg = _parse_with_env({"YB_MCP_MAX_RESULT_BYTES": "1048576"})
+        assert cfg.max_result_bytes == 1_048_576
+
+
+class TestPoolSizingValidation:
+    """DB-22159 round-2: pool_min_size <= pool_max_size is enforced at
+    app_lifespan startup, not silently at pool.open time."""
+
+    def test_min_larger_than_max_rejected(self):
+        """The bad combo is caught inside app_lifespan before the pool is
+        opened. parse_config accepts the individual values (both are just
+        positive ints); the relational check runs later."""
+        from yugabytedb_mcp_server import server as server_module
+        cfg = _parse_with_env({
+            "YB_MCP_POOL_MIN_SIZE": "10",
+            "YB_MCP_POOL_MAX_SIZE": "5",
+        })
+        assert cfg.pool_min_size == 10
+        assert cfg.pool_max_size == 5
+
+        original = getattr(server_module, "CONFIG", None)
+        server_module.CONFIG = cfg
+        try:
+            async def _drive():
+                async with server_module.app_lifespan(None) as _:
+                    pass
+            import asyncio
+            with pytest.raises(ValueError, match="POOL_MIN_SIZE"):
+                asyncio.run(_drive())
+        finally:
+            if original is None:
+                try:
+                    del server_module.CONFIG
+                except AttributeError:
+                    pass
+            else:
+                server_module.CONFIG = original
+
 
 class TestResourceLimitEnvValidation:
     """Bad env values fail startup with a clean argparse error, not a
-    traceback. Same pattern that DB-22162 will apply to max_insert_rows
-    in the follow-up release."""
+    traceback."""
 
     def test_pool_max_size_rejects_non_int(self):
         with pytest.raises(SystemExit):

--- a/tests/test_http_startup.py
+++ b/tests/test_http_startup.py
@@ -48,6 +48,7 @@ _BASE_CONFIG = ServerConfig(
     pool_max_size=5,
     statement_timeout_ms=30_000,
     max_result_rows=10_000,
+    max_result_bytes=50 * 1024 * 1024,
     max_query_len=100_000,
 )
 

--- a/tests/test_integration_reads.py
+++ b/tests/test_integration_reads.py
@@ -274,6 +274,36 @@ async def test_statement_timeout_kills_slow_query(mcp_session_capped):
     )
 
 
+async def test_result_byte_cap_truncates(mcp_session_capped, test_schema, db_conn):
+    """DB-22159 round-2 repro. A query with FEW rows (well under
+    max_result_rows) but WIDE rows now truncates by cumulative byte size
+    — the old fetchmany(row_cap+1) buffered wide rows without bound and
+    could OOM the process. The capped fixture sets max_result_bytes=512
+    so ~5 rows of a 200-char string is enough to trip the cap.
+    """
+    with db_conn.cursor() as cur:
+        cur.execute(f'CREATE TABLE "{test_schema}".wide (val TEXT)')
+        cur.execute(
+            f'INSERT INTO "{test_schema}".wide '
+            f"SELECT repeat('x', 200) FROM generate_series(1, 3)"
+        )
+
+    result = await mcp_session_capped.call_tool(
+        "run_read_only_query",
+        {"query": f'SELECT val FROM "{test_schema}".wide'},
+    )
+    parsed = parse_json(result)
+    assert isinstance(parsed, dict), f"expected dict shape, got: {parsed!r}"
+    assert parsed.get("truncated") is True
+    # 3 rows total, each ~200 chars. Under a 3-row cap AND 512-byte cap,
+    # the byte cap should trip first — only 1-2 rows survive.
+    assert 1 <= parsed.get("returned_rows", 0) <= 2, (
+        f"expected byte cap to trip before row cap; got returned_rows="
+        f"{parsed.get('returned_rows')}"
+    )
+    assert "YB_MCP_MAX_RESULT_BYTES" in parsed.get("note", "")
+
+
 async def test_result_row_cap_truncates(mcp_session_capped, test_schema, db_conn):
     """DB-22159 second repro. A query returning MORE than
     YB_MCP_MAX_RESULT_ROWS (3 in the capped fixture) truncates with a

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -42,6 +42,7 @@ _BASE_CONFIG = ServerConfig(
     pool_max_size=3,
     statement_timeout_ms=30_000,
     max_result_rows=10_000,
+    max_result_bytes=50 * 1024 * 1024,
     max_query_len=100_000,
 )
 


### PR DESCRIPTION
## Summary

Vishal's re-verification on main (9a0cda7) confirmed DB-22159 round 1 fixed most of the availability holes, but four gaps remained. This PR closes them.

**Stacked on #13** — merge #13 first, then re-target to `main`.

## Four fixes

### 1. `YB_MCP_MAX_RESULT_BYTES` (byte cap)

The row cap alone doesn't bound a wide-row query: `SELECT repeat('x', 1_000_000) FROM generate_series(1, 100)` still materialized ~100 MB. Replaced `fetchmany(max+1)` with a row-by-row iterator that tracks cumulative approximate byte cost. Default cap 50 MiB.

### 2. `summarize_database` statement_timeout

Only `run_read_only_query` and `run_write_query` applied `SET LOCAL statement_timeout`. A slow `COUNT(*)` on a huge table via `summarize_database` could hold a pool connection indefinitely. Now applies the same cap.

### 3. Pool sizing validation

`pool_min_size > pool_max_size` surfaced as a raw psycopg traceback at `pool.open` time. Now caught at `app_lifespan` start with a clean `ValueError` naming both env vars.

### 4. `connect_timeout` on conninfo

libpq's default is unlimited. A network partition hung startup or pool checkouts for hundreds of seconds. Now appends `connect_timeout=10` when the operator's conninfo doesn't include one.

## Tests

- `test_config.py::test_max_result_bytes_default` / `_from_env`
- `test_config.py::TestPoolSizingValidation::test_min_larger_than_max_rejected` — drives `app_lifespan` with `min=10, max=5`
- `test_integration_reads.py::test_result_byte_cap_truncates` — 3 wide rows against a 512-byte cap fixture
- `conftest.py::mcp_session_capped` — adds `YB_MCP_MAX_RESULT_BYTES=512`

Full suite: **394 passed** (unit + integration on live YB).

## Manual test plan

### Byte cap
```
YUGABYTEDB_URL="host=127.0.0.1 port=5433 user=yugabyte dbname=yugabyte" \\
  uv run pytest tests/test_integration_reads.py::test_result_byte_cap_truncates -v
```

### summarize_database timeout
```
psql "host=127.0.0.1 port=5433 user=yugabyte dbname=yugabyte" -c \\
  "DROP TABLE IF EXISTS big22159; CREATE TABLE big22159 AS SELECT g FROM generate_series(1, 5000000) g;"
printf '%s\n' \\
  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"x","version":"1"}}}' \\
  '{"jsonrpc":"2.0","method":"notifications/initialized"}' \\
  '{"jsonrpc":"2.0","id":100,"method":"tools/call","params":{"name":"summarize_database","arguments":{"schema":"public"}}}' > /tmp/db22159.jsonl
YUGABYTEDB_URL="host=127.0.0.1 port=5433 user=yugabyte dbname=yugabyte" YB_MCP_STATEMENT_TIMEOUT_MS=500 bash -c \\
  '{ cat /tmp/db22159.jsonl; sleep 8; } | uv run yugabytedb-mcp --transport stdio 2>/dev/null | jq ".result.content[0].text | fromjson[] | select(.error)"'
```
Expect a per-table `error` mentioning `canceling statement due to statement timeout`.

### Pool min>max
```
YB_MCP_POOL_MIN_SIZE=10 YB_MCP_POOL_MAX_SIZE=5 YUGABYTEDB_URL="host=127.0.0.1 port=5433 user=yugabyte dbname=yugabyte" \\
  uv run yugabytedb-mcp --transport stdio 2>&1 | grep -i POOL_MIN
```
Expect the `YB_MCP_POOL_MIN_SIZE (10) exceeds…` error.

Verify:

- [x] Byte cap trips with `YB_MCP_MAX_RESULT_BYTES` in the note
- [x] Slow `summarize_database` COUNT is killed by statement_timeout
- [x] Pool `min > max` fails at startup with a clean message
- [x] `connect_timeout=10` visible in conninfo log