### PR TITLE
HTTP defaults round 2 (DB-22139): MCP_PORT + fail-closed Origin when auth is off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ _(No unreleased changes.)_
 
 ### Added
 
+- **`MCP_PORT` / `--port` config.** HTTP transport now honors a
+  configurable port instead of the hardcoded `8000`. Env:
+  `MCP_PORT`, default `8000`. (DB-22139 round 2.)
 - **`YB_MCP_MAX_RESULT_BYTES` cap.** Cumulative byte budget applied
   while streaming rows from `run_read_only_query`. A wide-row query
   (e.g. `SELECT repeat('x', 1_000_000) FROM generate_series(1, 100)`)
@@ -31,6 +34,10 @@ _(No unreleased changes.)_
 - **`summarize_database` now runs under `SET LOCAL statement_timeout`**,
   matching the read / write tools. A slow `COUNT(*)` no longer
   holds a pool connection indefinitely. (DB-22159 round 2.)
+- **HTTP transport fails closed when auth is off and no Origin
+  allowlist is configured** — previously a warning; now a startup
+  error, matching the auth-off + non-loopback guard. Same escape
+  hatch: `MCP_ALLOW_UNAUTHENTICATED=true`. (DB-22139 round 2.)
 
 ### Changed
 

--- a/src/yugabytedb_mcp_server/server.py
+++ b/src/yugabytedb_mcp_server/server.py
@@ -93,6 +93,7 @@ class ServerConfig:
     yugabytedb_url: str
     transport: str
     host: str
+    port: int
     stateless_http: bool
     ssl_root_cert_secret_arn: str | None
     ssl_root_cert_key: str | None
@@ -353,6 +354,12 @@ def parse_config() -> ServerConfig:
              "(env: MCP_HOST, default: 127.0.0.1)",
     )
     parser.add_argument(
+        "--port",
+        type=_positive_int,
+        default=os.environ.get("MCP_PORT", "8000"),
+        help="Bind port for HTTP transport (env: MCP_PORT, default: 8000).",
+    )
+    parser.add_argument(
         "--stateless-http",
         action="store_true",
         default=os.environ.get("YB_MCP_STATELESS_HTTP", "").lower() == "true",
@@ -513,6 +520,7 @@ def parse_config() -> ServerConfig:
         yugabytedb_url=args.yugabytedb_url,
         transport=args.transport,
         host=args.host,
+        port=args.port,
         stateless_http=args.stateless_http,
         ssl_root_cert_secret_arn=args.yb_aws_ssl_root_cert_secret_arn,
         ssl_root_cert_key=args.yb_aws_ssl_root_cert_key,
@@ -567,9 +575,11 @@ class YugabyteDBMCPServer:
         else:
             logger.info("run_write_query tool disabled (use --enable-write-query or YB_MCP_ENABLE_WRITE_QUERY=true to enable)")
 
-    def run(self, port=8000):
+    def run(self, port: int | None = None):
         if CONFIG.transport == "http":
-            self._run_http(CONFIG.host, port)
+            # DB-22139: port is now a real config value (MCP_PORT / --port).
+            # Fall back to the argument for callers that still pass one.
+            self._run_http(CONFIG.host, port if port is not None else CONFIG.port)
         else:
             self.mcp.run(transport="stdio")
 
@@ -777,11 +787,24 @@ def _check_http_startup(host: str) -> None:
             "=" * 78
         )
 
-    # Independent of auth: an empty Origin allowlist means the
-    # DNS-rebinding defense is off (OriginValidationMiddleware no-ops
-    # when allowed_origins is empty). Warn — non-fatal — so operators
-    # who run browser clients see the gap in logs.
-    if not _parse_allowed_origins():
+    # DB-22139 round-2: when auth is OFF, the Origin allowlist is the only
+    # thing standing between the loopback bind and a browser DNS-rebinding
+    # attack. Fail closed when both are missing rather than emitting a
+    # warning and continuing. Escape hatch: the same
+    # ``MCP_ALLOW_UNAUTHENTICATED=true`` opt-in the auth guard uses.
+    empty_origins = not _parse_allowed_origins()
+    if not has_auth and empty_origins and not allow_unauth:
+        logger.critical(
+            "HTTP transport with no auth provider AND no Origin allowlist. "
+            "DNS-rebinding defense is OFF, so a browser page can drive "
+            "requests to this loopback bind. Set MCP_ALLOWED_ORIGINS "
+            "(comma-separated) or MCP_BASE_URL to enable the allowlist, "
+            "configure MCP_AUTH_PROVIDER, or set "
+            "MCP_ALLOW_UNAUTHENTICATED=true for dev/testing only."
+        )
+        sys.exit(1)
+
+    if empty_origins:
         logger.warning(
             "HTTP transport is running with no Origin allowlist "
             "configured — DNS-rebinding defense is OFF. Set "

--- a/src/yugabytedb_mcp_server/server.py
+++ b/src/yugabytedb_mcp_server/server.py
@@ -88,6 +88,20 @@ def _positive_int(s: str) -> int:
     return v
 
 
+def _tcp_port(s: str) -> int:
+    """argparse `type=` helper for MCP_PORT. Requires 1 <= port <= 65535
+    so a typo (`MCP_PORT=65536`) fails at parse_config with a clear
+    argparse error instead of an uglier uvicorn socket-bind traceback
+    at startup."""
+    try:
+        v = int(s)
+    except (ValueError, TypeError):
+        raise argparse.ArgumentTypeError(f"must be an integer 1–65535, got {s!r}")
+    if not (1 <= v <= 65535):
+        raise argparse.ArgumentTypeError(f"must be 1–65535, got {v}")
+    return v
+
+
 @dataclass
 class ServerConfig:
     yugabytedb_url: str
@@ -355,9 +369,10 @@ def parse_config() -> ServerConfig:
     )
     parser.add_argument(
         "--port",
-        type=_positive_int,
+        type=_tcp_port,
         default=os.environ.get("MCP_PORT", "8000"),
-        help="Bind port for HTTP transport (env: MCP_PORT, default: 8000).",
+        help="Bind port for HTTP transport, 1–65535 "
+             "(env: MCP_PORT, default: 8000).",
     )
     parser.add_argument(
         "--stateless-http",
@@ -719,14 +734,32 @@ def _resolve_auth_scope() -> str | None:
     return None
 
 
-_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
+_LOOPBACK_NAMES = frozenset({"localhost"})
 
 
 def _is_loopback(host: str) -> bool:
     """True if `host` is a loopback address / name. Used by the DB-22139
     refuse-to-start guard to decide whether an unauth deployment is
-    acceptable (loopback-only = OK; any other bind = require auth)."""
-    return host.strip().lower() in _LOOPBACK_HOSTS
+    acceptable (loopback-only = OK; any other bind = require auth).
+
+    Normalizes:
+    - strips surrounding whitespace and IPv6 brackets (`[::1]`)
+    - lowercases
+    - matches the full ``127.0.0.0/8`` block, not just ``127.0.0.1``
+    - matches every IPv6 loopback form via ``ipaddress.ip_address`` —
+      that catches ``::1``, ``0:0:0:0:0:0:0:1``, and any zero-prefix
+      abbreviation libpq / uvicorn would accept
+    """
+    import ipaddress
+    h = host.strip().lower()
+    if h.startswith("[") and h.endswith("]"):
+        h = h[1:-1]
+    if h in _LOOPBACK_NAMES:
+        return True
+    try:
+        return ipaddress.ip_address(h).is_loopback
+    except ValueError:
+        return False
 
 
 def _env_bool(name: str) -> bool:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -120,6 +120,21 @@ class TestHttpBindConfig:
         with pytest.raises(SystemExit):
             _parse_with_env({"MCP_PORT": "0"})
 
+    def test_port_rejects_above_65535(self):
+        """DB-22139 round-2 (post-review): port must fit a TCP port. 65536
+        used to slip through _positive_int and later crashed uvicorn with
+        a raw socket-bind traceback."""
+        with pytest.raises(SystemExit):
+            _parse_with_env({"MCP_PORT": "65536"})
+
+    def test_port_rejects_negative(self):
+        with pytest.raises(SystemExit):
+            _parse_with_env({"MCP_PORT": "-1"})
+
+    def test_port_accepts_65535(self):
+        cfg = _parse_with_env({"MCP_PORT": "65535"})
+        assert cfg.port == 65535
+
 
 class TestResourceLimitEnvParsing:
     """Env-var overrides populate ServerConfig correctly."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -99,6 +99,27 @@ class TestResourceLimitDefaults:
         cfg = _parse_with_env({})
         assert cfg.max_result_bytes == 50 * 1024 * 1024
 
+    def test_port_default(self):
+        """DB-22139 round-2: MCP_PORT defaults to 8000."""
+        cfg = _parse_with_env({})
+        assert cfg.port == 8000
+
+
+class TestHttpBindConfig:
+    """DB-22139: MCP_HOST and MCP_PORT come from env / --host / --port."""
+
+    def test_port_from_env(self):
+        cfg = _parse_with_env({"MCP_PORT": "9090"})
+        assert cfg.port == 9090
+
+    def test_port_rejects_non_int(self):
+        with pytest.raises(SystemExit):
+            _parse_with_env({"MCP_PORT": "abc"})
+
+    def test_port_rejects_zero(self):
+        with pytest.raises(SystemExit):
+            _parse_with_env({"MCP_PORT": "0"})
+
 
 class TestResourceLimitEnvParsing:
     """Env-var overrides populate ServerConfig correctly."""

--- a/tests/test_http_startup.py
+++ b/tests/test_http_startup.py
@@ -31,6 +31,7 @@ _BASE_CONFIG = ServerConfig(
     yugabytedb_url="host=localhost port=5433 user=yugabyte dbname=yugabyte",
     transport="http",
     host="127.0.0.1",
+    port=8000,
     stateless_http=False,
     ssl_root_cert_secret_arn=None,
     ssl_root_cert_key=None,
@@ -154,14 +155,39 @@ class TestCheckHttpStartup:
         # No CRITICAL log for the auth gap either.
         assert not any(r.levelname == "CRITICAL" for r in caplog.records)
 
-    def test_loopback_no_auth_starts(self, with_config, caplog):
-        """Loopback bind without auth is fine — no one outside the box
-        can reach the port."""
+    def test_loopback_no_auth_with_allowlist_starts(self, with_config, caplog):
+        """Loopback bind without auth is fine WHEN an Origin allowlist is
+        configured — DNS-rebinding defense catches browser attacks that
+        would otherwise reach 127.0.0.1."""
         with_config(host="127.0.0.1", auth_provider=None)
-        caplog.set_level("WARNING")
-        _check_http_startup("127.0.0.1")  # doesn't exit
-        # No CRITICAL log for the auth gap.
+        with patch.dict(os.environ, {"MCP_ALLOWED_ORIGINS": "https://mcp.example.com"}), \
+             caplog.at_level("WARNING"):
+            _check_http_startup("127.0.0.1")  # doesn't exit
         assert not any(r.levelname == "CRITICAL" for r in caplog.records)
+
+    def test_loopback_no_auth_no_allowlist_refuses_to_start(self, with_config, caplog):
+        """DB-22139 round-2: loopback + no auth + no Origin allowlist =
+        a browser DNS-rebinding attack can reach the loopback bind. Fail
+        closed rather than warn-and-continue."""
+        with_config(host="127.0.0.1", auth_provider=None)
+        with caplog.at_level("CRITICAL"):
+            with pytest.raises(SystemExit) as exc:
+                _check_http_startup("127.0.0.1")
+        assert exc.value.code == 1
+        combined_log = " ".join(r.message for r in caplog.records)
+        assert "DNS-rebinding" in combined_log
+        assert "MCP_ALLOWED_ORIGINS" in combined_log
+
+    def test_loopback_no_auth_no_allowlist_with_escape_starts(
+        self, with_config, caplog,
+    ):
+        """The same escape hatch (MCP_ALLOW_UNAUTHENTICATED=true) that
+        lets the public + no-auth case run also covers the no-allowlist
+        case, since both live in the same defense-in-depth layer."""
+        with_config(host="127.0.0.1", auth_provider=None)
+        with patch.dict(os.environ, {"MCP_ALLOW_UNAUTHENTICATED": "true"}), \
+             caplog.at_level("WARNING"):
+            _check_http_startup("127.0.0.1")  # doesn't exit
 
     def test_loopback_with_auth_starts(self, with_config):
         """Loopback with auth is definitely fine."""

--- a/tests/test_http_startup.py
+++ b/tests/test_http_startup.py
@@ -94,7 +94,11 @@ def clean_env():
 class TestIsLoopback:
     @pytest.mark.parametrize("host", [
         "127.0.0.1",
+        "127.0.0.2",       # full 127.0.0.0/8 block is loopback (post-review fix)
+        "127.255.255.254",
         "::1",
+        "[::1]",           # bracketed IPv6 form (post-review fix)
+        "0:0:0:0:0:0:0:1", # expanded IPv6 form (post-review fix)
         "localhost",
         "LOCALHOST",       # case-insensitive
         " 127.0.0.1 ",     # whitespace tolerated
@@ -108,6 +112,8 @@ class TestIsLoopback:
         "10.0.0.1",
         "mcp.example.com",
         "",
+        "::",              # unspecified — not loopback
+        "not-an-ip",
     ])
     def test_non_loopback_hosts(self, host):
         assert _is_loopback(host) is False

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -25,6 +25,7 @@ _BASE_CONFIG = ServerConfig(
     yugabytedb_url="host=localhost port=5433 user=yugabyte dbname=yugabyte",
     transport="stdio",
     host="127.0.0.1",
+    port=8000,
     stateless_http=False,
     ssl_root_cert_secret_arn=None,
     ssl_root_cert_key=None,


### PR DESCRIPTION
## Summary

Vishal's re-verification on main (9a0cda7) confirmed HTTP mode fails closed on non-loopback host + no auth (round 1). Two gaps remained; this PR closes them.

**Stacked on #14** — merge #13 → #14 first, then re-target to `main`.

## Two fixes

### 1. `MCP_PORT` / `--port` config

Port was hardcoded to 8000. `MCP_HOST` was already configurable; port wasn't. Added `MCP_PORT` env + `--port` CLI arg (default 8000), threaded through `ServerConfig` and `YugabyteDBMCPServer.run()`.

### 2. Origin fail-closed when auth is off

When auth is off, an empty Origin allowlist meant the DNS-rebinding defense was fully off — a browser page could drive requests to the loopback bind. Previously a warning; now `_check_http_startup` fails closed with a CRITICAL log unless `MCP_ALLOW_UNAUTHENTICATED=true` (same escape hatch as the auth-off + non-loopback guard).

## Tests

- `test_config.py::test_port_default` / `TestHttpBindConfig::test_port_from_env` / `_rejects_non_int` / `_rejects_zero`
- `test_http_startup.py`: `test_loopback_no_auth_starts` split into three cases — `_with_allowlist_starts`, `_no_allowlist_refuses_to_start`, `_no_allowlist_with_escape_starts`.
- `_BASE_CONFIG` in `test_http_startup.py` and `test_registration.py` gets `port=8000`.

Full suite: **400 passed** (unit + integration on live YB).

## Manual test plan

### Port config
```
MCP_PORT=8888 YUGABYTEDB_URL="host=127.0.0.1 port=5433 user=yugabyte dbname=yugabyte" \\
  uv run yugabytedb-mcp --transport http &
sleep 3
curl -s -o /dev/null -w '%{http_code}\n' -X POST http://127.0.0.1:8888/mcp   # 400/406 = server bound to 8888
kill %1
```

### Fail-closed on missing allowlist
```
YUGABYTEDB_URL="host=127.0.0.1 port=5433 user=yugabyte dbname=yugabyte" \\
```
Expect a CRITICAL log and exit 1.

### Escape hatch works
```
MCP_ALLOW_UNAUTHENTICATED=true YUGABYTEDB_URL="host=127.0.0.1 port=5433 user=yugabyte dbname=yugabyte" \\
  uv run yugabytedb-mcp --transport http &
sleep 3
curl -s -o /dev/null -w '%{http_code}\n' -X POST http://127.0.0.1:8000/mcp   # server up
kill %1
```

Verify:

- [x] MCP_PORT actually binds the requested port
- [x] Loopback + no auth + no allowlist fails with `DNS-rebinding` in the log
- [x] `MCP_ALLOW_UNAUTHENTICATED=true` reverts to warning-only